### PR TITLE
`isos_update` accepts external BSL forcing

### DIFF
--- a/src/green_functions.f90
+++ b/src/green_functions.f90
@@ -9,7 +9,7 @@ module green_functions
     
     public :: calc_viscous_green
     public :: calc_elastic_green
-    public :: calc_ssh_green
+    public :: calc_z_ss_green
     public :: get_ge_value
     public :: calc_gn_value
     
@@ -95,8 +95,8 @@ module green_functions
         return 
       end subroutine calc_elastic_green
 
-    ! Compute Green function (Coulon et al. 2021) to determine the SSH perturbation.
-    subroutine calc_ssh_green(filt, m_earth, r_earth, dx, dy) 
+    ! Compute Green function (Coulon et al. 2021) to determine the z_ss perturbation.
+    subroutine calc_z_ss_green(filt, m_earth, r_earth, dx, dy) 
         implicit none 
 
         real(wp), intent(OUT) :: filt(:, :) 
@@ -134,7 +134,7 @@ module green_functions
         end do
 
         return
-    end subroutine calc_ssh_green
+    end subroutine calc_z_ss_green
 
 
       function get_ge_value(r,rn_vals,ge_vals) result(ge)

--- a/src/isos_utils.f90
+++ b/src/isos_utils.f90
@@ -211,7 +211,7 @@ module isos_utils
 
         ref%z_bed           = now%z_bed
         ref%rsl             = now%rsl
-        ref%ssh             = now%ssh
+        ref%z_ss             = now%z_ss
 
         return
     end subroutine copy_sparsestate
@@ -224,7 +224,7 @@ module isos_utils
         call copy_sparsestate(ref, now)
         ref%dwdt            = now%dwdt
         ref%Haf             = now%Haf
-        ref%ssh_perturb     = now%ssh_perturb
+        ref%z_ss_perturb     = now%z_ss_perturb
         ref%canom_load      = now%canom_load
         ref%canom_full      = now%canom_full
         ref%mass_anom       = now%mass_anom
@@ -270,12 +270,12 @@ module isos_utils
 
         output%Hice = now%Hice(i1:i2, j1:j2)
         output%rsl = now%rsl(i1:i2, j1:j2)
-        output%ssh = now%ssh(i1:i2, j1:j2)
+        output%z_ss = now%z_ss(i1:i2, j1:j2)
         output%z_bed = now%z_bed(i1:i2, j1:j2)
         output%dwdt = now%dwdt(i1:i2, j1:j2)
         output%w = now%w(i1:i2, j1:j2)
         output%we = now%we(i1:i2, j1:j2)
-        output%ssh_perturb = now%ssh_perturb(i1:i2, j1:j2)
+        output%z_ss_perturb = now%z_ss_perturb(i1:i2, j1:j2)
         output%canom_full = now%canom_full(i1:i2, j1:j2)
 
         output%maskocean = now%maskocean(i1:i2, j1:j2)
@@ -322,20 +322,20 @@ module isos_utils
         return
     end subroutine calc_cropindices
 
-    subroutine extendice2isostasy(now, z_bed, H_ice, ssh, i1, i2, j1, j2)
+    subroutine extendice2isostasy(now, z_bed, H_ice, z_ss, i1, i2, j1, j2)
         implicit none
         type(isos_state_class), intent(INOUT)   :: now
         real(wp), intent(IN)                    :: z_bed(:, :)
         real(wp), intent(IN)                    :: H_ice(:, :)
-        real(wp), intent(IN)                    :: ssh(:, :)
+        real(wp), intent(IN)                    :: z_ss(:, :)
         integer, intent(IN)                     :: i1, i2, j1, j2
 
         now%z_bed = 0.0
         now%Hice = 0.0
-        now%ssh = 0.0
+        now%z_ss = 0.0
         now%z_bed(i1:i2, j1:j2) = z_bed
         now%Hice(i1:i2, j1:j2) = H_ice
-        now%ssh(i1:i2, j1:j2) = ssh
+        now%z_ss(i1:i2, j1:j2) = z_ss
         return
     end subroutine extendice2isostasy
 

--- a/src/isostasy_defs.f90
+++ b/src/isostasy_defs.f90
@@ -82,7 +82,7 @@ module isostasy_defs
         real(wp), allocatable   :: kei(:, :)   ! Kelvin function filter values
         real(wp), allocatable   :: GV(:, :)    ! Green's function values
         real(wp), allocatable   :: GE(:, :)    ! Green's function for elastic displacement (Farrell 1972)
-        real(wp), allocatable   :: GN(:, :)    ! Green's function for ssh_perturb
+        real(wp), allocatable   :: GN(:, :)    ! Green's function for z_ss_perturb
 
         complex(wp), allocatable :: FGV(:, :)    ! FFT of GV
         complex(wp), allocatable :: FGE(:, :)    ! FFT of GE
@@ -106,8 +106,8 @@ module isostasy_defs
         ! real(wp), allocatable :: Hsediment(:, :)     ! [m] Thickness of sediment column
 
         real(wp), allocatable :: rsl(:, :)           ! [m] relative sea level
-        real(wp), allocatable :: ssh(:, :)           ! [m] sea-surface height
-        real(wp), allocatable :: ssh_perturb(:, :)   ! [m] sea-surface height perturbation
+        real(wp), allocatable :: z_ss(:, :)           ! [m] sea-surface height
+        real(wp), allocatable :: z_ss_perturb(:, :)   ! [m] sea-surface height perturbation
         real(wp), allocatable :: canom_load(:, :)    ! [kg m^-2] Load column anomaly
         real(wp), allocatable :: canom_full(:, :)    ! [kg m^-2] Full column anomaly
         real(wp), allocatable :: mass_anom(:, :)     ! [kg] Mass anomaly
@@ -136,8 +136,8 @@ module isostasy_defs
         real(wp), allocatable       :: w_equilibrium(:, :)
 
         real(wp), allocatable       :: rsl(:, :)
-        real(wp), allocatable       :: ssh(:, :)
-        real(wp), allocatable       :: ssh_perturb(:, :)
+        real(wp), allocatable       :: z_ss(:, :)
+        real(wp), allocatable       :: z_ss_perturb(:, :)
         real(wp), allocatable       :: z_bed(:, :)
 
         logical, allocatable        :: maskocean(:, :)

--- a/src/sealevel.f90
+++ b/src/sealevel.f90
@@ -28,8 +28,12 @@ module sealevel
 
         isos%now%canom_load(:, :) = 0
         call add_columnanom(isos%par%rho_ice, isos%now%Hice, isos%ref%Hice, isos%now%canom_load)
-        call add_columnanom(isos%par%rho_seawater, isos%now%rsl, isos%ref%rsl, &
-            isos%now%canom_load, isos%now%maskocean)
+
+        if (isos%par%interactive_sealevel) then
+            call add_columnanom(isos%par%rho_seawater, isos%now%rsl, isos%ref%rsl, &
+                isos%now%canom_load, isos%now%maskocean)
+        end if
+
         call maskfield(isos%now%canom_load, isos%now%canom_load, isos%domain%maskactive, &
             isos%domain%nx, isos%domain%ny)
     end subroutine calc_columnanoms_load


### PR DESCRIPTION
This PR mainly extends `isos_update` s.t. a (scalar) external BSL forcing can be provided. @alex-robinson and I discussed the possibility of making this forcing heterogeneous (and therefore a matrix). This is not implemented yet, since BSL is a *scalar quantity* and it remains unclear which "sea-level field" represents what we want (and therefore unclear how it should be called, handled... etc.). However, this should be an enhancement for the near future.

Additionally, the sea-level is now always updated (even if `isos%par%interactive_sl .eq. false`) but the water load is not applied and `z_ss_perturb` is set to `0`.

Finally, this PR renames `ssh` to `z_ss`, for more coherence with the yelmo variable names.