### PR TITLE
Precision modifications

### DIFF
--- a/config/Makefile
+++ b/config/Makefile
@@ -33,6 +33,9 @@ endif
 ###############################################
 
 # 0 dependence
+$(objdir)/precision.o: $(srcdir)/precision.f90
+	$(FC) $(DFLAGS) $(FFLAGS) $(INC_NC) -c -o $@ $<
+
 $(objdir)/isostasy_defs.o: $(srcdir)/isostasy_defs.f90
 	$(FC) $(DFLAGS) $(FFLAGS) -c -o $@ $<
 
@@ -75,7 +78,8 @@ $(objdir)/fastisostasy.o: $(srcdir)/fastisostasy.f90 $(objdir)/isostasy_defs.o $
 $(objdir)/isostasy_benchmarks.o: $(srcdir)/isostasy_benchmarks.f90 $(objdir)/isostasy_defs.o
 	$(FC) $(DFLAGS) $(FFLAGS) -c -o $@ $<
 
-isostasy_libs = 		$(objdir)/isostasy_defs.o \
+isostasy_libs = 		$(objdir)/precision.o \
+						$(objdir)/isostasy_defs.o \
 						$(objdir)/isos_utils.o \
 						$(objdir)/convolutions.o \
 						$(objdir)/finite_differences.o \

--- a/src/convolutions.f90
+++ b/src/convolutions.f90
@@ -1,7 +1,7 @@
 
 module convolutions
 
-    use isostasy_defs, only : wp, pi, isos_domain_class
+    use isostasy_defs, only : sp, dp, wp, pi, isos_domain_class
     use isos_utils
 
     use, intrinsic :: iso_c_binding
@@ -62,15 +62,15 @@ module convolutions
         implicit none
 
         real(wp),    intent(OUT)    :: out(:, :)
-        complex(wp), intent(IN)     :: kernel(:, :)
+        complex(dp), intent(IN)     :: kernel(:, :)
         real(wp), intent(IN)        :: in(:, :)
         integer, intent(IN)         :: i1, i2, j1, j2, nx, ny, offset
         type(c_ptr), intent(IN)     :: forward_plan
         type(c_ptr), intent(IN)     :: backward_plan
 
         ! Local variables
-        real(wp),    allocatable    :: helper_real(:, :)
-        complex(wp), allocatable    :: helper_cplx(:, :)
+        real(dp),    allocatable    :: helper_real(:, :)
+        complex(dp), allocatable    :: helper_cplx(:, :)
 
         ! Populate load on extended grid
         allocate(helper_real(2*nx-1, 2*ny-1))
@@ -85,7 +85,7 @@ module convolutions
         helper_cplx =  kernel * helper_cplx
         call calc_fft_backward_c2r(backward_plan, helper_cplx, helper_real)
 
-        call apply_zerobc_at_corners(helper_real, 2*nx-1, 2*ny-1)
+        call apply_zerobc_at_corners_dp(helper_real, 2*nx-1, 2*ny-1)
         out(1:nx, 1:ny) = helper_real(i1+offset:i2+offset, j1-offset:j2-offset)
         return
     end subroutine precomputed_fftconvolution
@@ -95,12 +95,12 @@ module convolutions
 
         type(c_ptr), intent(IN)     :: plan
         real(wp),    intent(IN)     :: kernel(:, :)
-        complex(wp), intent(INOUT)  :: fftkernel(:, :)
-        real(wp), allocatable       :: extended_kernel(:, :)
+        complex(dp), intent(INOUT)  :: fftkernel(:, :)
+        real(dp), allocatable       :: extended_kernel(:, :)
         integer, intent(INOUT)      :: nx, ny
 
         allocate(extended_kernel(2*nx-1, 2*ny-1))
-        extended_kernel = 0.0_wp
+        extended_kernel = 0.0_dp
         extended_kernel(1:nx, 1:ny) = kernel
         call calc_fft_forward_r2c(plan, extended_kernel, fftkernel)
 

--- a/src/isos_utils.f90
+++ b/src/isos_utils.f90
@@ -1,7 +1,7 @@
 module isos_utils
 
     use, intrinsic :: iso_c_binding
-    use isostasy_defs, only : wp, pi, isos_domain_class, isos_param_class, &
+    use isostasy_defs, only : sp, dp, wp, pi, isos_domain_class, isos_param_class, &
         isos_state_class, isos_output_class
 
     implicit none
@@ -17,7 +17,8 @@ module isos_utils
     public :: calc_heterogeneous_rigidity
 
     public :: apply_zerobc_at_corners
-
+    public :: apply_zerobc_at_corners_dp 
+    
     public :: calc_fft_backward_r2r
     public :: calc_fft_forward_r2r
     public :: calc_fft_backward_c2r
@@ -101,6 +102,14 @@ module isos_utils
         return
     end subroutine apply_zerobc_at_corners
 
+    subroutine apply_zerobc_at_corners_dp(x, nx, ny)
+        real(dp), intent(INOUT) :: x(:, :)
+        integer, intent(IN)     :: nx, ny
+
+        x = x - 0.25 * (x(1,1) + x(nx,ny) + x(1,ny) + x(nx,1))
+        return
+    end subroutine apply_zerobc_at_corners_dp
+
 
     ! ===== FFT Functions ==============================
 
@@ -128,8 +137,8 @@ module isos_utils
 
         implicit none 
         type(c_ptr), intent(IN)     :: plan
-        real(wp), intent(INOUT)     :: in(:, :)
-        real(wp), intent(INOUT)     :: out(:, :)
+        real(dp), intent(INOUT)     :: in(:, :)
+        real(dp), intent(INOUT)     :: out(:, :)
 
         call fftw_execute_r2r(plan, in, out)
 
@@ -142,8 +151,8 @@ module isos_utils
         implicit none 
 
         type(c_ptr), intent(IN)     :: plan
-        real(wp), intent(INOUT)     :: in(:, :)
-        real(wp), intent(INOUT)     :: out(:, :)
+        real(dp), intent(INOUT)     :: in(:, :)
+        real(dp), intent(INOUT)     :: out(:, :)
 
         integer(kind=4)            :: nx, ny
         nx = size(in,1)
@@ -171,8 +180,8 @@ module isos_utils
         implicit none 
 
         type(c_ptr), intent(IN)     :: plan
-        real(wp), intent(INOUT)     :: in(:, :)
-        complex(wp), intent(INOUT)  :: out(:, :)
+        real(dp),    intent(INOUT)  :: in(:, :)
+        complex(dp), intent(INOUT)  :: out(:, :)
 
         call fftw_execute_dft_r2c(plan, in, out)
 
@@ -183,8 +192,8 @@ module isos_utils
         implicit none
 
         type(c_ptr), intent(IN)    :: plan
-        complex(wp), intent(INOUT) :: in(:, :)
-        real(wp), intent(INOUT)    :: out(:, :)
+        complex(dp), intent(INOUT) :: in(:, :)
+        real(dp),    intent(INOUT) :: out(:, :)
 
         integer(kind=4)            :: nx, ny
         nx = size(in,1)

--- a/src/isostasy_defs.f90
+++ b/src/isostasy_defs.f90
@@ -1,15 +1,16 @@
 module isostasy_defs
 
     use, intrinsic :: iso_c_binding
+    use precision
     implicit none
     include 'fftw3.f03'
 
     ! Internal constants
-    integer,  parameter :: dp  = kind(1.d0)
-    integer,  parameter :: sp  = kind(1.0)
+    ! integer,  parameter :: dp  = kind(1.d0)
+    ! integer,  parameter :: sp  = kind(1.0)
 
-    ! Choose the precision of the library (sp,dp)
-    integer,  parameter :: wp = dp
+    ! ! Choose the precision of the library (sp,dp)
+    ! integer,  parameter :: wp = dp
     real(wp), parameter :: pi = 3.14159265359
 
     type isos_param_class
@@ -84,9 +85,9 @@ module isostasy_defs
         real(wp), allocatable   :: GE(:, :)    ! Green's function for elastic displacement (Farrell 1972)
         real(wp), allocatable   :: GN(:, :)    ! Green's function for z_ss_perturb
 
-        complex(wp), allocatable :: FGV(:, :)    ! FFT of GV
-        complex(wp), allocatable :: FGE(:, :)    ! FFT of GE
-        complex(wp), allocatable :: FGN(:, :)    ! FFT of GN
+        complex(dp), allocatable :: FGV(:, :)    ! FFT of GV
+        complex(dp), allocatable :: FGE(:, :)    ! FFT of GE
+        complex(dp), allocatable :: FGN(:, :)    ! FFT of GN
 
     end type isos_domain_class
 
@@ -153,6 +154,7 @@ module isostasy_defs
         type(isos_output_class) :: output
     end type
 
+    public :: sp, dp, wp
     public :: isos_param_class
     public :: isos_domain_class
     public :: isos_state_class

--- a/src/lv_elva.f90
+++ b/src/lv_elva.f90
@@ -2,7 +2,7 @@
 module lv_elva
 
     use, intrinsic :: iso_c_binding
-    use isostasy_defs, only : wp, pi, isos_domain_class, isos_param_class
+    use isostasy_defs, only : sp, dp, wp, pi, isos_domain_class, isos_param_class
     use finite_differences
     use isos_utils
 
@@ -48,9 +48,11 @@ module lv_elva
         type(c_ptr), intent(IN) :: backward_plan
 
         real(wp), allocatable :: p(:, :)
-        real(wp), allocatable :: f(:, :)
-        real(wp), allocatable :: f_hat(:, :)
-        real(wp), allocatable :: dwdt_hat(:, :)
+        real(dp), allocatable :: f(:, :)
+        real(dp), allocatable :: f_hat(:, :)
+        real(dp), allocatable :: dwdt_hat(:, :)
+
+        real(dp), allocatable :: dwdt_dp(:,:) 
 
         real(wp), allocatable :: w_x(:, :)
         real(wp), allocatable :: w_xy(:, :)
@@ -70,6 +72,8 @@ module lv_elva
         allocate(f(nx, ny))
         allocate(f_hat(nx, ny))
         allocate(dwdt_hat(nx, ny))
+
+        allocate(dwdt_dp(nx, ny))
 
         allocate(w_x(nx, ny))
         allocate(w_xy(nx, ny))
@@ -108,9 +112,10 @@ module lv_elva
         dwdt_hat = f_hat / kappa
 
         ! write(*,*) sum(dwdt_hat), sum(f_hat)
-        call calc_fft_backward_r2r(backward_plan, dwdt_hat, dwdt)
-        call apply_zerobc_at_corners(dwdt, nx, ny)
-
+        call calc_fft_backward_r2r(backward_plan, dwdt_hat, dwdt_dp)
+        call apply_zerobc_at_corners_dp(dwdt_dp, nx, ny)
+        dwdt = dwdt_dp 
+        
         ! Rate of viscous asthenosphere uplift per unit time (seconds)
         dwdt = dwdt * sec_per_year  !  [m/s] x [s/a] = [m/a]
 

--- a/src/precision.f90
+++ b/src/precision.f90
@@ -1,0 +1,18 @@
+module precision
+
+    implicit none
+
+    ! Internal constants
+    integer,  parameter :: dp  = kind(1.d0)
+    integer,  parameter :: sp  = kind(1.0)
+
+    ! Choose the precision of the library (sp,dp)
+    integer,  parameter :: wp = sp 
+    
+    ! Tolerance settings
+    real(wp), parameter :: TOL           = real(1e-5,wp)
+    real(wp), parameter :: TOL_UNDERFLOW = real(1e-15,wp)
+
+contains 
+
+end module precision


### PR DESCRIPTION
…lity, compatibility with other modules. Set default precision wp=sp. Defined several internal fastisostasy fields as dp for handling ffts, while outward facing fields are all defined with wp. Test2 appears to work as normal.