### PR TITLE
Correct methods 0 and 1

### DIFF
--- a/src/fastisostasy.f90
+++ b/src/fastisostasy.f90
@@ -551,12 +551,12 @@ module fastisostasy
             ! Step 1: diagnose equilibrium displacement and rate of bedrock uplift
             select case(isos%par%method)
 
-                ! Steady-state lithosphere
+                ! Case 0 turns off vertical displacement
                 case(0)
-                    call calc_llra_equilibrium(isos%now%w_equilibrium, &
-                        isos%now%canom_load, isos%par%rho_uppermantle)
-                        isos%now%w    = isos%now%w_equilibrium
-                        isos%now%dwdt = 0.0
+                    ! call calc_llra_equilibrium(isos%now%w_equilibrium, &
+                    !     isos%now%canom_load, isos%par%rho_uppermantle)
+                    !     isos%now%w    = isos%now%w_equilibrium
+                    !     isos%now%dwdt = 0.0
 
                 ! LLRA
                 case(1)

--- a/src/lv_xlra.f90
+++ b/src/lv_xlra.f90
@@ -34,7 +34,7 @@ module lv_xlra
         real(wp), intent(INOUT) :: canom_load(:, :)     ! [Pa] Lithospheric load
         real(wp), intent(IN)    :: rho_uppermantle
 
-        w_equilibrium = canom_load / rho_uppermantle
+        w_equilibrium = - canom_load / rho_uppermantle
         
         return
     end subroutine calc_llra_equilibrium


### PR DESCRIPTION
Method 0 was thus far referring to "constant displacement". This is somewhat misleading, since it calls LLRA to determine the equilibrium displacement and impose it as the transient displacement. I believe method 0 should simply turn off the isostasy, which is something we often want to do.

Method 1 calls LLRA with the transient displacement computed from a relaxation equation of the equilibrium displacement. We were however having a wrong sign there, which is corrected in this PR.