### PR TITLE
Fix `isos%out` dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ call isos_init_state(isos1, z_bed, H_ice, time)
 do time = 1, nt
     ! ...
     call isos_update(isos1, H_ice, time, dwdt_corr=dzbdt_corr)
-    z_bed = isos1%output%z_bed
-    z_sl  = isos1%output%z_ss
+    z_bed = isos1%out%z_bed
+    z_sl  = isos1%out%z_ss
     ! ...
 end do
 

--- a/par/test_isostasy_test2.nml
+++ b/par/test_isostasy_test2.nml
@@ -5,7 +5,7 @@
     method          = 3             ! 0: constant displacement; 1: LLRA; 2: LV-ELRA, 3: LV-ELVA
     dt_prognostics  = 1.            ! [yr] Max. timestep to recalculate prognostics
     dt_diagnostics  = 10.           ! [yr] Min. timestep to recalculate diagnostics
-    pad         = 0.e3              ! [m] Padding around the domain (preferably chosen as a power
+    pad         = 512.e3              ! [m] Padding around the domain (preferably chosen as a power
                                     ! of 2 multiplied by the resolution)
 
     ! Rheology

--- a/par/test_isostasy_test5.nml
+++ b/par/test_isostasy_test5.nml
@@ -1,20 +1,21 @@
+
 &isostasy
     ! Options
-    interactive_sealevel = .true.   ! Sea level interacts with solid Earth deformation?
-    correct_distortion = .false.    ! Account for distortion of projection?
-    method          = 3             ! 0: constant displacement; 1: LLRA; 2: LV-ELRA, 3: LV-ELVA
-    dt_prognostics  = 1.0           ! [yr] Max. timestep to recalculate prognostics
-    dt_diagnostics  = 10.           ! [yr] Min. timestep to recalculate diagnostics
-    mantle     = uniform       ! Type of viscosity field for sub-lithospheric mantle
-    lithosphere = uniform       ! Type of thickness filed for elastic lithosphere
+    interactive_sealevel = .true.
+    correct_distortion = .false.
+    method          = 3
+    dt_prognostics  = 1.
+    dt_diagnostics  = 10.
+    pad         = 512.e3
 
-    ! 1D reference model
-    nl          = 2                 ! [1] Number of viscous layers for sub-lithospheric mantle
-    zl  = 88.0, 600.0       ! [km] Depth of layer boundaries. The first value is overwritten
-                                    ! if a lithospheric thickness filed is provided.
-    viscosities = 1.e21, 2.e21      ! [Pa s] Layer viscosities. The values are overwritten if a 3D
-                                    ! viscosity field is provided.
-    tau         = 2000.0            ! [yr] Relaxation time
+    ! Rheology
+    mantle = "uniform"
+    lithosphere = "uniform"
+    viscosity_scaling_method = 0
+    layering    = "equalized"
+    nl          = 2
+    zl          = 88., 600.
+    viscosities = 1e21, 2e21
 
     ! Physical constants
     E               = 66.0          ! [GPa] Young modulus
@@ -28,4 +29,10 @@
     r_earth         = 6.378e6       ! [m]  Earth radius, Coulon et al. (2021)
     m_earth         = 5.972e24      ! [kg] Earth mass,   Coulon et al. (2021)
     A_ocean_pd      = 3.625e14      ! [m^2] Ocean surface as in Goelzer et al. (2020)
+
+    ! Files
+    restart = "None"
+    mask_file = "None"
+    rheology_file = "None"
+    ocean_surface_file = "None"
 /

--- a/src/convolutions.f90
+++ b/src/convolutions.f90
@@ -22,7 +22,7 @@ module convolutions
         type(isos_domain_class), intent(INOUT)  :: domain
 
         call calc_convolution_indices(domain%i1, domain%i2, domain%j1, domain%j2, &
-            domain%offset, domain%ny, domain%nx)
+            domain%offset, domain%nx, domain%ny)
         return
     end subroutine convenient_calc_convolution_indices
 

--- a/src/fastisostasy.f90
+++ b/src/fastisostasy.f90
@@ -170,7 +170,7 @@ module fastisostasy
             trim(isos%par%mask_file) .eq. "none" .or. &
             trim(isos%par%mask_file) .eq. "no") then
             
-            if (isos%par%interactive_sealevel .eq. .false.) then
+            if (isos%par%interactive_sealevel .eqv. .false.) then
                 isos%domain%maskactive = .true.
             else if (isos%par%min_pad > 100.e3) then
                 isos%domain%maskactive(isos%domain%icrop1:isos%domain%icrop2, &

--- a/src/fastisostasy.f90
+++ b/src/fastisostasy.f90
@@ -172,11 +172,11 @@ module fastisostasy
             
             if (isos%par%interactive_sealevel .eq. .false.) then
                 isos%domain%maskactive = .true.
-            else if (isos%domain%n_pad_xy > 10) then
+            else if (isos%par%min_pad > 100.e3) then
                 isos%domain%maskactive(isos%domain%icrop1:isos%domain%icrop2, &
                     isos%domain%jcrop1:isos%domain%jcrop2) = .true.
             else
-                write(*,*) "interactive_sealevel=.true. requires a mask file or a padded domain."
+                write(*,*) "interactive_sealevel=.true. requires a mask file or at least 100km of padding."
                 stop
             end if
         else

--- a/src/fastisostasy.f90
+++ b/src/fastisostasy.f90
@@ -585,8 +585,8 @@ module fastisostasy
                 update_diagnostics = .FALSE.
             end if
 
-            write (*,*) "time_prog, time_diag, update_diag: ", &
-                isos%par%time_prognostics, isos%par%time_diagnostics, update_diagnostics
+            ! write (*,*) "time_prog, time_diag, update_diag: ", &
+            !     isos%par%time_prognostics, isos%par%time_diagnostics, update_diagnostics
 
             ! write(*,*) "isos_update:: updating load anomalies..."
             call calc_columnanoms_load(isos)

--- a/src/fastisostasy.f90
+++ b/src/fastisostasy.f90
@@ -157,9 +157,17 @@ module fastisostasy
         isos%domain%maskactive(:, :) = .false.
         if (trim(isos%par%mask_file) .eq. "None" .or. &
             trim(isos%par%mask_file) .eq. "none" .or. &
-            trim(isos%par%mask_file) .eq. "no") then 
-            isos%domain%maskactive(isos%domain%icrop1:isos%domain%icrop2, &
-                isos%domain%jcrop1:isos%domain%jcrop2) = .true.
+            trim(isos%par%mask_file) .eq. "no") then
+            
+            if (isos%par%interactive_sealevel .eq. .false.) then
+                isos%domain%maskactive = .true.
+            else if (isos%domain%n_pad_xy > 10) then
+                isos%domain%maskactive(isos%domain%icrop1:isos%domain%icrop2, &
+                    isos%domain%jcrop1:isos%domain%jcrop2) = .true.
+            else
+                write(*,*) "interactive_sealevel=.true. requires a mask file or a padded domain."
+                stop
+            end if
         else
             call nc_read(isos%par%mask_file, "M", &
                 buffer_n(isos%domain%icrop1:isos%domain%icrop2, &

--- a/src/isos_utils.f90
+++ b/src/isos_utils.f90
@@ -285,6 +285,8 @@ module isos_utils
 
         domain%dx = dx
         domain%dy = dy
+        domain%nx_ice = nx_ice
+        domain%ny_ice = ny_ice
         domain%icrop1 = 1
         domain%jcrop1 = 1
 
@@ -578,7 +580,7 @@ module isos_utils
         call isos_set_field(var, var_values, mask_values, mask)
         
         ! Apply Gaussian smoothing as desired
-        call smooth_gauss_2D(var, dx,sigma)
+        call smooth_gauss_2D(var, dx, sigma)
         
         return
     end subroutine isos_set_smoothed_field

--- a/src/isostasy_defs.f90
+++ b/src/isostasy_defs.f90
@@ -67,7 +67,7 @@ module isostasy_defs
     end type
 
     type isos_domain_class
-        integer                 :: nx_ice, ny_ice, pad_x, pad_y, n_pad
+        integer                 :: nx_ice, ny_ice, n_pad_x, n_pad_y, n_pad_xy
         integer                 :: i1, i2, j1, j2
         integer                 :: icrop1, icrop2, jcrop1, jcrop2
         integer                 :: offset
@@ -143,7 +143,7 @@ module isostasy_defs
         logical, allocatable :: maskcontinent(:, :)  ! [1] Continent mask
     end type isos_state_class
 
-    type isos_output_class
+    type isos_out_class
         real(wp), allocatable       :: He_lith(:, :)
         real(wp), allocatable       :: D_lith(:, :)
         real(wp), allocatable       :: eta_eff(:, :)
@@ -169,14 +169,14 @@ module isostasy_defs
         logical, allocatable        :: maskocean(:, :)
         logical, allocatable        :: maskgrounded(:, :)
         logical, allocatable        :: maskcontinent(:, :)
-    end type isos_output_class
+    end type isos_out_class
 
     type isos_class
         type(isos_param_class)  :: par
         type(isos_domain_class) :: domain
         type(isos_state_class)  :: now
         type(isos_state_class)  :: ref
-        type(isos_output_class) :: output
+        type(isos_out_class) :: out
     end type
 
     public :: sp, dp, wp

--- a/tests/test_isostasy.f90
+++ b/tests/test_isostasy.f90
@@ -13,7 +13,8 @@ program test_isostasy
     character(len=512) :: parfldr
     character(len=512) :: outfldr
     character(len=512) :: path_par
-    character(len=512) :: file_out 
+    character(len=512) :: file_out
+    character(len=512) :: file_out_extended
 
     character(len=56)  :: experiment
     character(len=56)  :: mantle
@@ -49,7 +50,7 @@ program test_isostasy
 
     ! === Define experiment to be run ====
 
-    experiment = "test4"
+    experiment = "test5"
     
     ! Tests are defined in Swierczek-Jereczek et al. (2024), GMD.
     ! Additional: "test5" = Lucía's Greenland ice-sheet load (since 15 ka)
@@ -120,9 +121,9 @@ program test_isostasy
 
             case("test5")
                 time_init = 0.
-                time_end  = 15.e3
+                time_end  = 15.e1   ! 15.e3
                 dtt       = 1.0
-                dt_out    = 1.e3
+                dt_out    = 1.e1    ! 1.e3
                 dx = 16.e3
                 dy = dx
                 xmin = -840.e3
@@ -145,10 +146,12 @@ program test_isostasy
     outfldr = "output/"
     path_par = trim(parfldr)//"/"//"test_isostasy_"//trim(experiment)//".nml"
     file_out = trim(outfldr)//"/"//"bedtest_"//trim(experiment)// ".nc"
+    file_out_extended = trim(outfldr)//"/"//"bedtest_"//trim(experiment)// "_extended.nc"
     write(*,*) "outfldr: ",  trim(outfldr)
     write(*,*) "path_par: ", trim(path_par)
     write(*,*) "file_out: ", trim(file_out)
-    
+    write(*,*) "file_out_extended: ", trim(file_out_extended)
+
     write(*,*) "Initialising viscosity and rigidity fields..."
     mantle = "uniform"
     write(*,*) "viscosity field method = ", trim(mantle)
@@ -365,6 +368,7 @@ program test_isostasy
     ! stop
 
     call isos_write_init(isos1, xc, yc, file_out, time_init)
+    call isos_write_init_extended(isos1, file_out_extended, time_init)
 
     ! Determine total number of iterations to run
     nt = ceiling((time_end-time_init)/dtt) + 1
@@ -397,6 +401,7 @@ program test_isostasy
                 case DEFAULT
                     z_bed_bench = 0.0
                     call isos_write_step(isos1, file_out, time, H_ice)
+                    call isos_write_step_extended(isos1, file_out_extended, time)
 
             end select
 
@@ -433,35 +438,35 @@ program test_isostasy
             units="year", unlimited=.TRUE.)
 
         ! Write constant fields
-        call nc_write(filename, "He_lith", isos%output%He_lith, units="km", &
+        call nc_write(filename, "He_lith", isos%out%He_lith, units="km", &
             long_name="Lithosphere thickness", dim1="xc", dim2="yc" ,start=[1, 1])
 
-        ! call nc_write(filename,"GE",isos%output%GE, units="", &
+        ! call nc_write(filename,"GE",isos%out%GE, units="", &
         !     long_name="Elastic Green function", dim1="xc", dim2="yc", start=[1, 1])
 
         ! if (isos%par%interactive_sealevel) then
-        !     call nc_write(filename, "GN", isos%output%GN, units="", &
+        !     call nc_write(filename, "GN", isos%out%GN, units="", &
         !     long_name="SSH Green function", dim1="xc", dim2="yc", start=[1, 1])
         ! end if
         
         if (isos%par%method .eq. 2) then
-            ! call nc_write(filename, "kei", isos%output%kei, units="", &
+            ! call nc_write(filename, "kei", isos%out%kei, units="", &
             !     long_name="Kelvin function filter", dim1="xc", dim2="yc", start=[1, 1])
 
-            ! call nc_write(filename,"GV",isos%output%GV, units="", &
+            ! call nc_write(filename,"GV",isos%out%GV, units="", &
             !     long_name="Viscous Green function", dim1="xc", dim2="yc", start=[1, 1])
 
-            call nc_write(filename, "tau", isos%output%tau, units="yr", &
+            call nc_write(filename, "tau", isos%out%tau, units="yr", &
                 long_name="Asthenosphere relaxation timescale", &
                 dim1="xc", dim2="yc", start=[1, 1])
         end if
 
         if (isos%par%method .eq. 3) then
-            call nc_write(filename, "log10_eta_eff", log10(isos%output%eta_eff), units="Pa s", &
+            call nc_write(filename, "log10_eta_eff", log10(isos%out%eta_eff), units="Pa s", &
                 long_name="Effective upper-mantle viscosity", &
                 dim1="xc", dim2="yc", start=[1, 1])
 
-            ! call nc_write(filename, "kappa", isos%output%kappa, units="", &
+            ! call nc_write(filename, "kappa", isos%out%kappa, units="", &
             !     long_name="Pseudodifferential operator in Fourier space", &
             !     dim1="xc", dim2="yc", start=[1, 1])
         end if
@@ -469,6 +474,64 @@ program test_isostasy
         return
 
     end subroutine isos_write_init
+
+    subroutine isos_write_init_extended(isos, filename, time_init)
+
+        implicit none
+
+        type(isos_class), intent(IN) :: isos
+        character(len=*), intent(IN) :: filename
+        real(wp),         intent(IN) :: time_init
+        
+        ! Local variables
+        integer :: nf
+        
+        ! Create the empty netcdf file
+        call nc_create(filename)
+        
+        ! Add grid axis variables to netcdf file
+        call nc_write_dim(filename, "xc", x=isos%domain%xc*1e-3, units="km")
+        call nc_write_dim(filename, "yc", x=isos%domain%yc*1e-3, units="km")
+        call nc_write_dim(filename, "time", x=time_init, dx=1.0_wp, nx=1, &
+            units="year", unlimited=.TRUE.)
+
+        ! Write constant fields
+        call nc_write(filename, "He_lith", isos%domain%He_lith, units="km", &
+            long_name="Lithosphere thickness", dim1="xc", dim2="yc" ,start=[1, 1])
+
+        call nc_write(filename,"GE",isos%domain%GE, units="", &
+            long_name="Elastic Green function", dim1="xc", dim2="yc", start=[1, 1])
+
+        if (isos%par%interactive_sealevel) then
+            call nc_write(filename, "GN", isos%domain%GN, units="", &
+            long_name="SSH Green function", dim1="xc", dim2="yc", start=[1, 1])
+        end if
+        
+        if (isos%par%method .eq. 2) then
+            call nc_write(filename, "kei", isos%domain%kei, units="", &
+                long_name="Kelvin function filter", dim1="xc", dim2="yc", start=[1, 1])
+
+            call nc_write(filename,"GV",isos%domain%GV, units="", &
+                long_name="Viscous Green function", dim1="xc", dim2="yc", start=[1, 1])
+
+            call nc_write(filename, "tau", isos%domain%tau, units="yr", &
+                long_name="Asthenosphere relaxation timescale", &
+                dim1="xc", dim2="yc", start=[1, 1])
+        end if
+
+        if (isos%par%method .eq. 3) then
+            call nc_write(filename, "log10_eta_eff", log10(isos%domain%eta_eff), units="Pa s", &
+                long_name="Effective upper-mantle viscosity", &
+                dim1="xc", dim2="yc", start=[1, 1])
+
+            ! call nc_write(filename, "kappa", isos%out%kappa, units="", &
+            !     long_name="Pseudodifferential operator in Fourier space", &
+            !     dim1="xc", dim2="yc", start=[1, 1])
+        end if
+
+        return
+
+    end subroutine isos_write_init_extended
 
     ! Write results to file
     subroutine isos_write_step(isos, filename, time, H_ice, z_bed_bench)
@@ -497,45 +560,45 @@ program test_isostasy
         call nc_write(filename,"time", time, dim1="time", start=[n], count=[1], ncid=ncid)
         
         ! Write variables
-        call nc_write(filename, "H_ice", isos%output%Hice, units="m", long_name="Ice thickness", &
+        call nc_write(filename, "H_ice", isos%out%Hice, units="m", long_name="Ice thickness", &
               dim1="xc", dim2="yc", dim3="time", start=[1, 1, n], ncid=ncid)
 
-        call nc_write(filename, "z_ss", isos%output%z_ss, units="m", long_name="Sea-surface height", &
+        call nc_write(filename, "z_ss", isos%out%z_ss, units="m", long_name="Sea-surface height", &
               dim1="xc", dim2="yc", dim3="time", start=[1, 1, n], ncid=ncid)
 
-        call nc_write(filename,"z_bed", isos%output%z_bed, units="m", &
+        call nc_write(filename,"z_bed", isos%out%z_bed, units="m", &
             long_name="Bedrock elevation", dim1="xc", dim2="yc", dim3="time", &
             start=[1, 1, n], ncid=ncid)
 
-        call nc_write(filename, "dwdt", isos%output%dwdt, units="m/yr", &
+        call nc_write(filename, "dwdt", isos%out%dwdt, units="m/yr", &
             long_name="Bedrock elevation change", &
             dim1="xc", dim2="yc", dim3="time", start=[1, 1, n], ncid=ncid)
 
-        call nc_write(filename, "w_viscous", isos%output%w, units="m", &
+        call nc_write(filename, "w_viscous", isos%out%w, units="m", &
             long_name="Displacement (viscous)", &
             dim1="xc", dim2="yc", dim3="time", start=[1, 1, n], ncid=ncid)
 
-        call nc_write(filename, "w_elastic", isos%output%we, units="m", &
+        call nc_write(filename, "w_elastic", isos%out%we, units="m", &
             long_name="Displacement (elastic)", &
             dim1="xc", dim2="yc", dim3="time", start=[1, 1, n], ncid=ncid)
 
-        call nc_write(filename, "z_ss_perturbation", isos%output%dz_ss, units="m", &
+        call nc_write(filename, "z_ss_perturbation", isos%out%dz_ss, units="m", &
             long_name="Geoid displacement", dim1="xc", dim2="yc", dim3="time", &
             start=[1, 1, n], ncid=ncid)
 
-        call nc_write(filename, "column_anomaly", isos%output%canom_full, units="N m^-2", &
+        call nc_write(filename, "column_anomaly", isos%out%canom_full, units="N m^-2", &
             long_name = "Anomaly in column pressure", &
             dim1="xc", dim2="yc", dim3="time", start=[1, 1, n], ncid=ncid)
 
-        call nc_write(filename, "ocean_mask", isos%output%maskocean, units="1", &
+        call nc_write(filename, "ocean_mask", isos%out%maskocean, units="1", &
             long_name = "Ocean mask", &
             dim1="xc", dim2="yc", dim3="time", start=[1, 1, n], ncid=ncid)
 
-        call nc_write(filename, "grounded_mask", isos%output%maskgrounded, units="1", &
+        call nc_write(filename, "grounded_mask", isos%out%maskgrounded, units="1", &
             long_name = "Grounded mask", &
             dim1="xc", dim2="yc", dim3="time", start=[1, 1, n], ncid=ncid)
 
-        call nc_write(filename, "continent_mask", isos%output%maskcontinent, units="1", &
+        call nc_write(filename, "continent_mask", isos%out%maskcontinent, units="1", &
             long_name = "Continent mask", &
             dim1="xc", dim2="yc", dim3="time", start=[1, 1, n], ncid=ncid)
 
@@ -555,5 +618,78 @@ program test_isostasy
 
         return 
     end subroutine isos_write_step
+
+
+    ! Write results to file
+    subroutine isos_write_step_extended(isos, filename, time)
+
+        implicit none 
+        
+        type(isos_class), intent(IN) :: isos
+        character(len=*), intent(IN) :: filename
+        real(wp),         intent(IN) :: time
+
+        ! Local variables
+        integer  :: ncid, n
+        real(wp) :: time_prev 
+
+        ! Open the file for writing
+        call nc_open(filename, ncid, writable=.TRUE.)
+
+        ! Determine current writing time step
+        n = nc_size(filename, "time", ncid)
+        call nc_read(filename, "time", time_prev, start=[n], count=[1], ncid=ncid)
+        if (abs(time-time_prev) .gt. 1e-5) n = n+1
+
+        ! Update the time step
+        call nc_write(filename,"time", time, dim1="time", start=[n], count=[1], ncid=ncid)
+        
+        ! Write variables
+        call nc_write(filename, "H_ice", isos%now%Hice, units="m", long_name="Ice thickness", &
+              dim1="xc", dim2="yc", dim3="time", start=[1, 1, n], ncid=ncid)
+
+        call nc_write(filename, "z_ss", isos%now%z_ss, units="m", long_name="Sea-surface height", &
+              dim1="xc", dim2="yc", dim3="time", start=[1, 1, n], ncid=ncid)
+
+        call nc_write(filename,"z_bed", isos%now%z_bed, units="m", &
+            long_name="Bedrock elevation", dim1="xc", dim2="yc", dim3="time", &
+            start=[1, 1, n], ncid=ncid)
+
+        call nc_write(filename, "dwdt", isos%now%dwdt, units="m/yr", &
+            long_name="Bedrock elevation change", &
+            dim1="xc", dim2="yc", dim3="time", start=[1, 1, n], ncid=ncid)
+
+        call nc_write(filename, "w_viscous", isos%now%w, units="m", &
+            long_name="Displacement (viscous)", &
+            dim1="xc", dim2="yc", dim3="time", start=[1, 1, n], ncid=ncid)
+
+        call nc_write(filename, "w_elastic", isos%now%we, units="m", &
+            long_name="Displacement (elastic)", &
+            dim1="xc", dim2="yc", dim3="time", start=[1, 1, n], ncid=ncid)
+
+        call nc_write(filename, "z_ss_perturbation", isos%now%dz_ss, units="m", &
+            long_name="Geoid displacement", dim1="xc", dim2="yc", dim3="time", &
+            start=[1, 1, n], ncid=ncid)
+
+        call nc_write(filename, "column_anomaly", isos%now%canom_full, units="N m^-2", &
+            long_name = "Anomaly in column pressure", &
+            dim1="xc", dim2="yc", dim3="time", start=[1, 1, n], ncid=ncid)
+
+        call nc_write(filename, "ocean_mask", isos%now%maskocean, units="1", &
+            long_name = "Ocean mask", &
+            dim1="xc", dim2="yc", dim3="time", start=[1, 1, n], ncid=ncid)
+
+        call nc_write(filename, "grounded_mask", isos%now%maskgrounded, units="1", &
+            long_name = "Grounded mask", &
+            dim1="xc", dim2="yc", dim3="time", start=[1, 1, n], ncid=ncid)
+
+        call nc_write(filename, "continent_mask", isos%now%maskcontinent, units="1", &
+            long_name = "Continent mask", &
+            dim1="xc", dim2="yc", dim3="time", start=[1, 1, n], ncid=ncid)
+
+        call nc_close(ncid)     ! Close the netcdf file
+
+        return 
+    end subroutine isos_write_step_extended
 
 end program test_isostasy

--- a/tests/test_isostasy.f90
+++ b/tests/test_isostasy.f90
@@ -121,9 +121,9 @@ program test_isostasy
 
             case("test5")
                 time_init = 0.
-                time_end  = 15.e1   ! 15.e3
+                time_end  = 15.e3
                 dtt       = 1.0
-                dt_out    = 1.e1    ! 1.e3
+                dt_out    = 1.e3
                 dx = 16.e3
                 dy = dx
                 xmin = -840.e3

--- a/tests/test_isostasy.f90
+++ b/tests/test_isostasy.f90
@@ -50,7 +50,7 @@ program test_isostasy
 
     ! === Define experiment to be run ====
 
-    experiment = "test5"
+    experiment = "test4"
     
     ! Tests are defined in Swierczek-Jereczek et al. (2024), GMD.
     ! Additional: "test5" = Lucía's Greenland ice-sheet load (since 15 ka)
@@ -529,6 +529,8 @@ program test_isostasy
             !     dim1="xc", dim2="yc", start=[1, 1])
         end if
 
+        call nc_write(filename, "maskactive", isos%domain%maskactive, units="1", &
+            long_name="Active mask", dim1="xc", dim2="yc", start=[1, 1])
         return
 
     end subroutine isos_write_init_extended
@@ -686,6 +688,7 @@ program test_isostasy
         call nc_write(filename, "continent_mask", isos%now%maskcontinent, units="1", &
             long_name = "Continent mask", &
             dim1="xc", dim2="yc", dim3="time", start=[1, 1, n], ncid=ncid)
+
 
         call nc_close(ncid)     ! Close the netcdf file
 

--- a/tests/test_isostasy.f90
+++ b/tests/test_isostasy.f90
@@ -50,7 +50,7 @@ program test_isostasy
 
     ! === Define experiment to be run ====
 
-    experiment = "test4"
+    experiment = "test3d"
     
     ! Tests are defined in Swierczek-Jereczek et al. (2024), GMD.
     ! Additional: "test5" = Lucía's Greenland ice-sheet load (since 15 ka)
@@ -611,7 +611,7 @@ program test_isostasy
             call nc_write(filename, "z_bed_bench", z_bed_bench,units="m", &
                 long_name="Benchmark bedrock elevation", &
                 dim1="xc", dim2="yc", dim3="time", start=[1, 1, n], ncid=ncid)
-            call nc_write(filename, "err_z_bed", isos%now%w - z_bed_bench,units="m", &
+            call nc_write(filename, "err_z_bed", isos%out%w - z_bed_bench,units="m", &
                 long_name="Error in bedrock elevation", &
                 dim1="xc", dim2="yc", dim3="time", start=[1, 1, n], ncid=ncid)
         end if


### PR DESCRIPTION
In #22, an error was introduced when generalising the padding options. This has now been corrected by introducing `subroutine init_domain_size()`, which handles the domain extension and the cropping in one go. Additionally, the initialisation of `z_bed_ref` was wrong and has now been corrected. 

Additionally, minor improvements include:
- `test_isostasy.f90` now writes an extra output file with the extended dimensions. This is very useful for debugging (which is the main purpose of this script along with testing).
- `in2out` and `out2in` were introduced to avoid complicated commands like `isos%out%w = isos%now%w(isos%domain%icrop1:isos%domain%icrop2, isos%domain%jcrop1:isos%domain%jcrop2)`.
- `maskactive` has a default definition which allows users to use `interactive_sealevel=true` without providing a mask, as long as they use a domain padding.
- `isos%output% was renamed to `isos%out% for conciseness.
- test 5 is passed and its namelist has been updated. This addresses #6.