### PR TITLE
Solved issue related to initialization of ref fields on a rectangular domain

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,32 +1,109 @@
-'''
+"""
 Script to generate Makefile with the correct compiler
 configuration for a given machine.
-'''
+"""
 
 from subprocess import *
 import argparse
-import sys 
+import sys
+import re
+
+def parse_makefile(filename="Makefile"):
+    """
+    Parses a Makefile and prints a list of available `make` commands (targets).
+    
+    Args:
+        filename (str): The path to the Makefile. Defaults to "Makefile".
+    """
+    try:
+        with open(filename, 'r') as file:
+            lines = file.readlines()
+            
+        targets = []
+        for line in lines:
+            # Strip comments and whitespace
+            line = line.split('#')[0].strip()
+            
+            # Match lines with targets (e.g., target: dependencies)
+            match = re.match(r'^([a-zA-Z0-9_-]+)\s*:\s*(.*)', line)
+            if match and not line.startswith('\t'):
+                target = match.group(1)
+                targets.append(target)
+        
+        print("Available `make` commands (targets):")
+        for target in targets:
+            print(f"  - {target}")
+        print("")
+        
+    except FileNotFoundError:
+        print(f"Error: File '{filename}' not found.")
+    except Exception as e:
+        print(f"An error occurred: {e}")
 
 # Manage command-line arguments to load compiler option
 parser = argparse.ArgumentParser()
 parser.add_argument(
-    'config', metavar='CONFIG', type=str,
-     help='Name of config file to use (e.g., config/pagos_gfortran)')
+    "config",
+    metavar="CONFIG",
+    type=str,
+    help="Name of config file to use (e.g., config/aire_gfortran)",
+)
 args = parser.parse_args()
 
 
 # Determine locations
-target_dir  = "./"
-config_dir  = "config/"
-config_path = args.config 
+target_dir = "./"
+config_dir = "config/"
+config_path = args.config
 
 # Load template Makefile and insert compiler configuration
-makefile0    = open(config_dir+"Makefile").read()
+makefile0 = open(config_dir + "Makefile").read()
 compile_info = open(config_path).read()
-makefile1 = makefile0.replace("<COMPILER_CONFIGURATION>",compile_info)
+makefile1 = makefile0.replace("<COMPILER_CONFIGURATION>", compile_info)
 
 # Write the new Makefile to the main directory
-open(target_dir+"Makefile","w").write(makefile1)
+open(target_dir + "Makefile", "w").write(makefile1)
 
-print( "".join(["\n\nMakefile configuration complete for configuration file: ",config_path,"\n"]) )
+print(
+    "".join(
+        [
+            "\n\nMakefile configuration complete for configuration file: ",
+            config_path,
+            "\n",
+        ]
+    )
+)
+
+# instructions = """==== How to run yelmo ====\n
+# # Make a link to the ice_data path, if available.
+# ln -s path/to/ice_data ice_data 
+
+# # Compile a test program
+# make clean 
+# make benchmarks      # makes executable libyelmo/bin/yelmo_benchmarks.x 
+
+# # Run the program using runylmo (see runylmo -h for details) 
+# ./runylmo -r -e benchmarks -o output/test -n par/yelmo_EISMINT.nml 
+
+# # Check the output 
+# cd output/test 
+# ncview yelmo2D.nc 
+# """
+
+# print(instructions)
+
+# Print usage
+parse_makefile("Makefile")
+
+
+### Old script commands to automatically determine the config_path from host + compiler:
+
+# Determine the current hostname
+# proc = Popen("hostname",shell=True,stdout=PIPE,stderr=PIPE)
+# host = proc.communicate()[0].strip().decode("utf-8")
+
+# if host == "manager.cei.ucm.local": host = "eolo"
+# if host in ["login01","login02"]:   host = "pik"
+
+# print("{}{}_{}".format(config_dir,host,compiler))
 

--- a/config/dkrz_levante_ifx
+++ b/config/dkrz_levante_ifx
@@ -8,7 +8,7 @@ LIB_NC  = -L${NETCDFFI_ROOT}/lib -Wl\,-rpath=${NETCDFFI_ROOT}/lib -lnetcdff -L${
 
 FFTWROOT = exlib/fftw-serial
 INC_FFTW = -I${FFTWROOT}/include
-LIB_FFTW = -L$(FFTWROOT)/lib -lfftw3 -lm
+LIB_FFTW = -L$(FFTWROOT)/lib -lfftw3
 
 FFLAGS  = -module $(objdir) -L$(objdir)
 
@@ -17,7 +17,7 @@ ifeq ($(openmp), 1)
 
     FFTWROOT = exlib/fftw-omp
     INC_FFTW = -I${FFTWROOT}/include
-    LIB_FFTW = -L$(FFTWROOT)/lib -lfftw3_omp -lfftw3 -lm
+    LIB_FFTW = -L$(FFTWROOT)/lib -lfftw3_omp -lfftw3
 
     FFLAGS  = -module $(objdir) -L$(objdir) -qopenmp 
 
@@ -26,5 +26,5 @@ endif
 LFLAGS  = $(LIB_NC) $(LIB_FFTW) -Wl,-zmuldefs
 
 DFLAGS_NODEBUG = -O2 -fp-model precise
-DFLAGS_DEBUG   = -C -traceback -ftrapuv -fpe0 -check all -fp-model precise
+DFLAGS_DEBUG   = -C -g -traceback -ftrapuv -fpe0 -check all,nouninit -fp-model precise
 DFLAGS_PROFILE = -O2 -fp-model precise -pg

--- a/config/pik_hpc2024_ifx
+++ b/config/pik_hpc2024_ifx
@@ -6,7 +6,7 @@ LIB_NC  = -L${NETCDFFI_ROOT}/lib -Wl\,-rpath=${NETCDFFI_ROOT}/lib -lnetcdff -L${
 
 FFTWROOT = exlib/fftw-serial
 INC_FFTW = -I${FFTWROOT}/include
-LIB_FFTW = -L${FFTWROOT}/lib -lfftw3 -lm
+LIB_FFTW = -L${FFTWROOT}/lib -lfftw3
 
 FFLAGS  = -module $(objdir) -L$(objdir)
 

--- a/par/test_isostasy_test1.nml
+++ b/par/test_isostasy_test1.nml
@@ -5,7 +5,7 @@
     method          = 3             ! 0: constant displacement; 1: LLRA; 2: LV-ELRA, 3: LV-ELVA
     dt_prognostics  = 1.            ! [yr] Max. timestep to recalculate prognostics
     dt_diagnostics  = 10.           ! [yr] Min. timestep to recalculate diagnostics
-    pad         = 0.e3              ! [m] Padding around the domain (preferably chosen as a power
+    pad         = 0.                ! [km] Padding around the domain (preferably chosen as a power
                                     ! of 2 multiplied by the resolution)
 
     ! Rheology

--- a/par/test_isostasy_test1.nml
+++ b/par/test_isostasy_test1.nml
@@ -13,7 +13,8 @@
                                     ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
     lithosphere = "uniform"   ! Choose lithospheric thickness field:
                                     ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
-    viscosity_scaling_method = 0    ! -1: min, 0: nominal, 1: max, else: scale by provided number
+    viscosity_scaling_method = "scale"  ! "scale" or "min" or "max"
+    viscosity_scaling = 1.              ! Only used if viscosity_scaling_method = "scale"
     layering    = "equalized"       ! "parallel", "equalized" or "folded"
     nl          = 1                 ! [1] Number of viscous layers for sub-lithospheric mantle
     zl = 88.0                       ! [km] Depth of layer boundaries. The first value is overwritten

--- a/par/test_isostasy_test2.nml
+++ b/par/test_isostasy_test2.nml
@@ -5,7 +5,7 @@
     method          = 3             ! 0: constant displacement; 1: LLRA; 2: LV-ELRA, 3: LV-ELVA
     dt_prognostics  = 1.            ! [yr] Max. timestep to recalculate prognostics
     dt_diagnostics  = 10.           ! [yr] Min. timestep to recalculate diagnostics
-    pad         = 512.e3              ! [m] Padding around the domain (preferably chosen as a power
+    pad         = 512.              ! [km] Padding around the domain (preferably chosen as a power
                                     ! of 2 multiplied by the resolution)
 
     ! Rheology
@@ -16,7 +16,7 @@
     viscosity_scaling_method = 0    ! -1: min, 0: nominal, 1: max, else: scale by provided number
     layering    = "equalized"       ! "parallel", "equalized" or "folded"
     nl          = 2                 ! [1] Number of viscous layers for sub-lithospheric mantle
-    zl = 70.0, 600.0                ! [km] Depth of layer boundaries. The first value is overwritten
+    zl = 70., 600.                  ! [km] Depth of layer boundaries. The first value is overwritten
                                     ! if a lithospheric thickness filed is provided.
     viscosities = 1.e21, 2.e21      ! [Pa s] Layer viscosities. Only used if
                                     ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".

--- a/par/test_isostasy_test2.nml
+++ b/par/test_isostasy_test2.nml
@@ -13,7 +13,8 @@
                                     ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
     lithosphere = "uniform"   ! Choose lithospheric thickness field:
                                     ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
-    viscosity_scaling_method = 0    ! -1: min, 0: nominal, 1: max, else: scale by provided number
+    viscosity_scaling_method = "scale"  ! "scale" or "min" or "max"
+    viscosity_scaling = 1.              ! Only used if viscosity_scaling_method = "scale"
     layering    = "equalized"       ! "parallel", "equalized" or "folded"
     nl          = 2                 ! [1] Number of viscous layers for sub-lithospheric mantle
     zl = 70., 600.                  ! [km] Depth of layer boundaries. The first value is overwritten

--- a/par/test_isostasy_test3a.nml
+++ b/par/test_isostasy_test3a.nml
@@ -10,7 +10,8 @@
     ! Rheology
     mantle = "uniform"
     lithosphere = "gaussian_minus"
-    viscosity_scaling_method = 0
+    viscosity_scaling_method = "scale"
+    viscosity_scaling = 1.
     layering    = "equalized"
     nl          = 1
     zl  = 150.

--- a/par/test_isostasy_test3a.nml
+++ b/par/test_isostasy_test3a.nml
@@ -5,7 +5,7 @@
     method          = 3
     dt_prognostics  = 1.
     dt_diagnostics  = 10.
-    pad         = 0.e3
+    pad         = 0.
 
     ! Rheology
     mantle = "uniform"

--- a/par/test_isostasy_test3b.nml
+++ b/par/test_isostasy_test3b.nml
@@ -10,7 +10,8 @@
     ! Rheology
     mantle = "uniform"
     lithosphere = "gaussian_plus"
-    viscosity_scaling_method = 0
+    viscosity_scaling_method = "scale"
+    viscosity_scaling = 1.
     layering    = "equalized"
     nl          = 1
     zl  = 150.

--- a/par/test_isostasy_test3b.nml
+++ b/par/test_isostasy_test3b.nml
@@ -5,7 +5,7 @@
     method          = 3
     dt_prognostics  = 1.
     dt_diagnostics  = 10.
-    pad         = 0.e3
+    pad         = 0.
 
     ! Rheology
     mantle = "uniform"

--- a/par/test_isostasy_test3c.nml
+++ b/par/test_isostasy_test3c.nml
@@ -10,7 +10,8 @@
     ! Rheology
     mantle = "gaussian_minus"
     lithosphere = "uniform"
-    viscosity_scaling_method = 0
+    viscosity_scaling_method = "scale"
+    viscosity_scaling = 1.
     layering    = "equalized"
     nl          = 1
     zl  = 150.

--- a/par/test_isostasy_test3c.nml
+++ b/par/test_isostasy_test3c.nml
@@ -5,7 +5,7 @@
     method          = 3
     dt_prognostics  = 1.
     dt_diagnostics  = 10.
-    pad         = 0.e3
+    pad         = 0.
 
     ! Rheology
     mantle = "gaussian_minus"

--- a/par/test_isostasy_test3d.nml
+++ b/par/test_isostasy_test3d.nml
@@ -5,7 +5,7 @@
     method          = 3
     dt_prognostics  = 1.
     dt_diagnostics  = 10.
-    pad         = 0.e3
+    pad         = 0.
 
     ! Rheology
     mantle = "gaussian_plus"

--- a/par/test_isostasy_test3d.nml
+++ b/par/test_isostasy_test3d.nml
@@ -10,7 +10,8 @@
     ! Rheology
     mantle = "gaussian_plus"
     lithosphere = "uniform"
-    viscosity_scaling_method = 0
+    viscosity_scaling_method = "scale"
+    viscosity_scaling = 1.
     layering    = "equalized"
     nl          = 1
     zl  = 150.

--- a/par/test_isostasy_test4.nml
+++ b/par/test_isostasy_test4.nml
@@ -5,12 +5,13 @@
     method          = 3
     dt_prognostics  = 1.
     dt_diagnostics  = 10.
-    pad         = 0.
+    pad         = 512.
 
     ! Rheology
     mantle = "rheology_file"
     lithosphere = "rheology_file"
-    viscosity_scaling_method = 0
+    viscosity_scaling_method = "scale"
+    viscosity_scaling = 1.
     layering    = "equalized"
     nl          = 3
     zl          = 260., 280., 300.

--- a/par/test_isostasy_test4.nml
+++ b/par/test_isostasy_test4.nml
@@ -5,7 +5,7 @@
     method          = 3
     dt_prognostics  = 1.
     dt_diagnostics  = 10.
-    pad         = 0.e3
+    pad         = 0.
 
     ! Rheology
     mantle = "rheology_file"

--- a/par/test_isostasy_test5.nml
+++ b/par/test_isostasy_test5.nml
@@ -6,7 +6,7 @@
     method          = 3
     dt_prognostics  = 1.
     dt_diagnostics  = 10.
-    pad         = 512.e3
+    pad         = 512.
 
     ! Rheology
     mantle = "uniform"

--- a/par/test_isostasy_test5.nml
+++ b/par/test_isostasy_test5.nml
@@ -11,7 +11,8 @@
     ! Rheology
     mantle = "uniform"
     lithosphere = "uniform"
-    viscosity_scaling_method = 0
+    viscosity_scaling_method = "scale"
+    viscosity_scaling = 1.
     layering    = "equalized"
     nl          = 2
     zl          = 88., 600.

--- a/src/fastisostasy.f90
+++ b/src/fastisostasy.f90
@@ -552,7 +552,7 @@ module fastisostasy
         call calc_masks(isos)
         ! write(*,*) "Calling first update..."
         ! call copy_sparsestate(isos%ref, isos%now)
-        call isos_update(isos, H_ice, time, force_update_diagnostics=.TRUE.)
+        call isos_update(isos, H_ice, time, bsl=bsl)
 
         ! write(*,*) "isos_init_state: "
         ! write(*,*) "    Initial time:   ",  isos%par%time_prognostics
@@ -573,7 +573,7 @@ module fastisostasy
 
     end subroutine isos_init_state
 
-    subroutine isos_update(isos, H_ice, time, bsl, dwdt_corr, force_update_diagnostics) 
+    subroutine isos_update(isos, H_ice, time, bsl, dwdt_corr) 
 
         implicit none
 
@@ -582,7 +582,6 @@ module fastisostasy
         real(wp), intent(IN)            :: time             ! [a] Current time
         real(wp), intent(IN), optional  :: bsl              ! [m] Barystatic sea level forcing
         real(wp), intent(IN), optional  :: dwdt_corr(:, :) ! [m/yr] Basal topography displacement rate (ie, to relax from low resolution to high resolution)
-        logical,  intent(IN), optional  :: force_update_diagnostics ! Internal switch to force update
 
         ! Local variables
         real(wp) :: dt, dt_now
@@ -623,8 +622,6 @@ module fastisostasy
             if ( (isos%par%time_prognostics+dt_now) - isos%par%time_diagnostics .ge. 1e-3) then
                 update_diagnostics = .TRUE.
                 isos%par%time_diagnostics = isos%par%time_diagnostics + isos%par%dt_diagnostics
-            else if (present(force_update_diagnostics)) then
-                update_diagnostics = .TRUE.
             else
                 update_diagnostics = .FALSE.
             end if

--- a/src/fastisostasy.f90
+++ b/src/fastisostasy.f90
@@ -801,7 +801,30 @@ module fastisostasy
         call nml_read(filename,group,"dt_prognostics",      par%dt_prognostics)
         call nml_read(filename,group,"pad",                 par%min_pad)
 
-        call nml_read(filename, group, "mask_file",             par%mask_file)
+        call nml_read(filename,group,"nl",          par%nl)
+        allocate(par%viscosities(par%nl))
+        allocate(par%zl(par%nl))
+        call nml_read(filename,group,"zl",          par%zl)
+
+        if (par%method .lt. 3) then     ! ELRA and LLRA
+            call nml_read(filename,group,"tau",             par%tau)
+
+        else                            ! ELVA
+            call nml_read(filename,group,"mantle",          par%mantle) 
+            call nml_read(filename,group,"lithosphere",     par%lithosphere)
+            call nml_read(filename,group,"layering",        par%layering)
+            call nml_read(filename,group,"viscosities",     par%viscosities)
+            
+            if (par%layering .eq. "parallel") then
+                call nml_read(filename,group,"dl",          par%dl)
+            end if
+
+            if ((par%mantle .eq. "rheology_file") .or. (par%lithosphere .eq. "rheology_file")) then
+                call nml_read(filename,group,"rheology_file", par%rheology_file)
+            end if
+        end if
+
+        call nml_read(filename, group, "mask_file",           par%mask_file)
 
         call nml_read(filename,group,"ocean_surface_file",    par%ocean_surface_file)
         if (trim(par%ocean_surface_file) .eq. "None" .or. &
@@ -819,29 +842,6 @@ module fastisostasy
             par%use_restart = .FALSE. 
         else 
             par%use_restart = .TRUE.
-        end if
-
-        if (par%method .lt. 3) then     ! ELRA and LLRA
-            call nml_read(filename,group,"tau",                 par%tau)
-
-        else                            ! ELVA
-            call nml_read(filename,group,"mantle",          par%mantle) 
-            call nml_read(filename,group,"lithosphere",     par%lithosphere)
-            call nml_read(filename,group,"layering",        par%layering)
-            call nml_read(filename,group,"nl",              par%nl)
-            allocate(par%viscosities(par%nl))
-            call nml_read(filename,group,"viscosities",     par%viscosities)
-            allocate(par%zl(par%nl))
-            call nml_read(filename,group,"zl",          par%zl)
-
-            if ((par%mantle .eq. "rheology_file") .or. (par%lithosphere .eq. "rheology_file")) then
-                call nml_read(filename,group,"rheology_file", par%rheology_file)
-            end if
-
-            if (par%layering .eq. "parallel") then
-                call nml_read(filename,group,"dl",                  par%dl)
-            end if
-
         end if
 
         return

--- a/src/fastisostasy.f90
+++ b/src/fastisostasy.f90
@@ -552,7 +552,7 @@ module fastisostasy
         call calc_masks(isos)
         ! write(*,*) "Calling first update..."
         ! call copy_sparsestate(isos%ref, isos%now)
-        call isos_update(isos, H_ice, time)
+        call isos_update(isos, H_ice, time, force_update_diagnostics=.TRUE.)
 
         ! write(*,*) "isos_init_state: "
         ! write(*,*) "    Initial time:   ",  isos%par%time_prognostics
@@ -573,7 +573,7 @@ module fastisostasy
 
     end subroutine isos_init_state
 
-    subroutine isos_update(isos, H_ice, time, bsl, dwdt_corr) 
+    subroutine isos_update(isos, H_ice, time, bsl, dwdt_corr, force_update_diagnostics) 
 
         implicit none
 
@@ -582,6 +582,7 @@ module fastisostasy
         real(wp), intent(IN)            :: time             ! [a] Current time
         real(wp), intent(IN), optional  :: bsl              ! [m] Barystatic sea level forcing
         real(wp), intent(IN), optional  :: dwdt_corr(:, :) ! [m/yr] Basal topography displacement rate (ie, to relax from low resolution to high resolution)
+        logical,  intent(IN), optional  :: force_update_diagnostics ! Internal switch to force update
 
         ! Local variables
         real(wp) :: dt, dt_now
@@ -622,6 +623,8 @@ module fastisostasy
             if ( (isos%par%time_prognostics+dt_now) - isos%par%time_diagnostics .ge. 1e-3) then
                 update_diagnostics = .TRUE.
                 isos%par%time_diagnostics = isos%par%time_diagnostics + isos%par%dt_diagnostics
+            else if (present(force_update_diagnostics)) then
+                update_diagnostics = .TRUE.
             else
                 update_diagnostics = .FALSE.
             end if

--- a/src/fastisostasy.f90
+++ b/src/fastisostasy.f90
@@ -460,6 +460,9 @@ module fastisostasy
         real(wp), intent(IN), optional :: bsl               ! [a] Barystatic sea level
         real(wp), intent(IN), optional :: dz_ss(:, :)       ! [m] Sea surface perturbation
         
+        isos%ref%z_bed = 0.0
+        isos%ref%Hice  = 0.0
+
         call out2in(isos%ref%z_bed, z_bed, isos%domain)
         call out2in(isos%ref%Hice,  H_ice, isos%domain)
 

--- a/src/fastisostasy.f90
+++ b/src/fastisostasy.f90
@@ -450,6 +450,7 @@ module fastisostasy
     end subroutine zero_init_state
 
     subroutine isos_init_ref(isos, z_bed, H_ice, bsl, dz_ss)
+        ! Set reference state from external fields with [nxo,nyo] dimensions
 
         implicit none
 
@@ -459,9 +460,9 @@ module fastisostasy
         real(wp), intent(IN), optional :: bsl               ! [a] Barystatic sea level
         real(wp), intent(IN), optional :: dz_ss(:, :)       ! [m] Sea surface perturbation
         
-        isos%ref%z_bed = z_bed
-        isos%ref%Hice = H_ice
-        
+        call out2in(isos%ref%z_bed, z_bed, isos%domain)
+        call out2in(isos%ref%Hice,  H_ice, isos%domain)
+
         if (present(bsl))   isos%ref%bsl   = bsl
         if (present(dz_ss)) isos%ref%dz_ss = dz_ss
         ! No need to set w, we, dz_ss and bsl to 0 because `zero_init_state(isos%ref)` in isos_init()
@@ -498,7 +499,8 @@ module fastisostasy
 
         else
             call out2in(isos%now%z_bed, z_bed, isos%domain)
-            call out2in(isos%now%Hice, H_ice, isos%domain)
+            call out2in(isos%now%Hice,  H_ice, isos%domain)
+
             if (present(bsl)) then
                 isos%now%bsl = bsl
             else
@@ -511,7 +513,7 @@ module fastisostasy
             end if
 
             if (.not. isos%par%ref_was_set) then
-                call isos_init_ref(isos, isos%now%z_bed, isos%now%Hice, isos%now%bsl, isos%now%dz_ss)
+                call isos_init_ref(isos, z_bed, H_ice, isos%now%bsl, isos%now%dz_ss)
                 write(*,*) "isos_init_state:: reference state was set to initial state."
             end if
 

--- a/src/fastisostasy.f90
+++ b/src/fastisostasy.f90
@@ -11,7 +11,8 @@ module fastisostasy
     
     use, intrinsic :: iso_fortran_env, only : input_unit, output_unit, error_unit
     use, intrinsic :: iso_c_binding
-
+    use, intrinsic :: ieee_arithmetic, only : ieee_is_nan
+    
     use isostasy_defs, only : sp, dp, wp, pi, isos_param_class, isos_state_class, &
         isos_domain_class, isos_out_class, isos_class
     use green_functions
@@ -754,6 +755,14 @@ module fastisostasy
         call cropstate2out(isos%out, isos%now, isos%domain)
         ! write(*,*) "extrema of w: ", minval(isos%now%w), maxval(isos%now%w)
         ! write(*,*) "extrema of we: ", minval(isos%now%we), maxval(isos%now%we)
+
+        ! ajr, diagnostics
+        if (ieee_is_nan(maxval(isos%now%z_bed)) .or. ieee_is_nan(maxval(isos%out%z_bed))) then
+            write(error_unit,*) "isos_update:: Error: NaNs detected."
+            write(error_unit,*) "now%z_bed: ", minval(isos%now%z_bed), maxval(isos%now%z_bed)
+            write(error_unit,*) "out%z_bed: ", minval(isos%out%z_bed), maxval(isos%out%z_bed)
+            stop
+        end if 
 
         return
     end subroutine isos_update

--- a/src/green_functions.f90
+++ b/src/green_functions.f90
@@ -74,26 +74,21 @@ module green_functions
 
         ! Fill matrix of Green function.
         filt = 0.
-        do j = -my, my
-        do i = -mx, mx
+        do j = 1, ny
+        do i = 1, nx
 
-            x  = i*dx
-            y  = j*dy
+            x  = (i-1-mx)*dx
+            y  = (j-1-mx)*dy
             r  = sqrt(x**2+y**2)
 
-            ! Get actual index of array
-            i1 = i+1+mx
-            j1 = j+1+my
-
             ! Get correct GE value for this point
-            filt(i1, j1) = get_ge_value(r, rn_vals, ge_vals) * 1.e-12 * (dx*dy) / &
+            filt(i, j) = get_ge_value(r, rn_vals, ge_vals) * 1.e-12 * (dx*dy) / &
                 (9.81*max(r, dx))
-
         end do
         end do
 
         return 
-      end subroutine calc_elastic_green
+    end subroutine calc_elastic_green
 
     ! Compute Green function (Coulon et al. 2021) to determine the z_ss perturbation.
     subroutine calc_z_ss_green(filt, m_earth, r_earth, dx, dy) 
@@ -117,19 +112,15 @@ module green_functions
 
         ! Fill matrix of Green function.
         filt = 0.
-        do j = -my, my
-        do i = -mx, mx
+        do j = 1, ny
+        do i = 1, nx
 
-            x  = i*dx
-            y  = j*dy
+            x  = (i-1-mx)*dx
+            y  = (j-1-mx)*dy
             r  = sqrt(x**2+y**2)
 
-            ! Get actual index of array
-            i1 = i+1+mx
-            j1 = j+1+my
-
             ! Get correct GE value for this point (given by colatitude, theta)
-            filt(i1, j1) = calc_gn_value(max(dy,r), r_earth, m_earth)
+            filt(i, j) = calc_gn_value(max(dy,r), r_earth, m_earth)
         end do
         end do
 
@@ -137,7 +128,7 @@ module green_functions
     end subroutine calc_z_ss_green
 
 
-      function get_ge_value(r,rn_vals,ge_vals) result(ge)
+    function get_ge_value(r,rn_vals,ge_vals) result(ge)
 
         implicit none
 

--- a/src/isos_utils.f90
+++ b/src/isos_utils.f90
@@ -144,6 +144,7 @@ module isos_utils
         real(dp), intent(INOUT)     :: in(:, :)
         real(dp), intent(INOUT)     :: out(:, :)
 
+        out = (0.d0,0.d0)
         call fftw_execute_r2r(plan, in, out)
 
         return
@@ -162,6 +163,7 @@ module isos_utils
         nx = size(in,1)
         ny = size(in,2)
 
+        out = (0.d0,0.d0)
         call fftw_execute_r2r(plan, in, out)
         out = out / (nx * ny * 1.)
 
@@ -187,6 +189,7 @@ module isos_utils
         real(dp),    intent(INOUT)  :: in(:, :)
         complex(dp), intent(INOUT)  :: out(:, :)
 
+        out = (0.d0,0.d0)
         call fftw_execute_dft_r2c(plan, in, out)
 
         return
@@ -203,6 +206,7 @@ module isos_utils
         nx = size(in,1)
         ny = size(in,2)
 
+        out = (0.d0,0.d0)
         call fftw_execute_dft_c2r(plan, in, out)
         out = out / (nx * ny * 1._wp)
 

--- a/src/isos_utils.f90
+++ b/src/isos_utils.f90
@@ -41,9 +41,11 @@ module isos_utils
     public :: maskfield
     public :: isos_set_field
     public :: isos_set_smoothed_field
+    public :: flat_extension
     public :: smooth_gauss_2D
+    public :: smooth_gauss_2D_masked
     public :: gauss_values
-    public :: calc_gaussian_rigidity
+    public :: calc_gaussian_thickness
     public :: calc_gaussian_viscosity
     
     contains
@@ -418,7 +420,6 @@ module isos_utils
         real(wp), intent(IN)                    :: H_ice(:, :)
         type(isos_domain_class), intent(IN)     :: domain
 
-        now%z_bed = 0.0
         now%Hice = 0.0
         call out2in(now%z_bed, z_bed, domain)
         call out2in(now%Hice, H_ice, domain)
@@ -589,6 +590,35 @@ module isos_utils
         return
     end subroutine isos_set_smoothed_field
 
+    subroutine flat_extension(var, icrop1, icrop2, jcrop1, jcrop2)
+        implicit none
+
+        real(wp), intent(INOUT) :: var(:, :)
+        integer, intent(IN)     :: icrop1, icrop2, jcrop1, jcrop2
+
+        integer :: i, j, nx, ny
+
+        nx = size(var,1)
+        ny = size(var,2)
+
+        do i = 1, nx
+            if (i .lt. icrop1) then
+                var(i,:) = var(icrop1,:)
+            else if (i .gt. icrop2) then
+                var(i,:) = var(icrop2,:)
+            end if
+        end do
+
+        do j = 1, ny
+            if (j .lt. jcrop1) then
+                var(:,j) = var(:,jcrop1)
+            else if (j .gt. jcrop2) then
+                var(:,j) = var(:,jcrop2)
+            end if
+        end do
+
+    end subroutine flat_extension
+
     subroutine smooth_gauss_2D(var, dx, sigma, mask_apply, mask_use)
         ! Smooth out a field to avoid noise 
         ! mask_apply designates where smoothing should be applied 
@@ -714,6 +744,103 @@ module isos_utils
         return
     end subroutine smooth_gauss_2D
 
+    subroutine smooth_gauss_2D_masked(var, dx, sigma, mask_apply, mask_use)
+        ! Smooth out a field to avoid noise 
+        ! mask_apply designates where smoothing should be applied 
+        ! mask_use   designates which points can be considered in the smoothing filter 
+
+        implicit none
+
+        real(wp),   intent(INOUT)   :: var(:, :)      ! [nx,ny] 2D variable
+        real(wp),   intent(IN)      :: dx 
+        real(wp),   intent(IN)      :: sigma  
+        logical,    intent(IN)      :: mask_apply(:, :) 
+        logical,    intent(IN)      :: mask_use(:, :) 
+
+        ! Local variables
+        integer  :: i, j, nx, ny, n, n2, k 
+        real(wp), allocatable :: filter0(:, :), filter(:, :) 
+        real(wp), allocatable :: var_old(:, :) 
+
+        real(wp), allocatable :: var_ext(:, :), var_ref_ext(:, :) 
+
+        nx    = size(var,1)
+        ny    = size(var,2)
+
+        ! Determine half-width of filter as 2-sigma
+        n2 = ceiling(2.0_wp*sigma / dx)
+
+        ! Get total number of points for filter window in each direction
+        n = 2*n2+1
+        
+        allocate(var_old(nx,ny))
+        allocate(filter0(n,n))
+        allocate(filter(n,n))
+
+        allocate(var_ext(-n2:nx+n2,-n2:ny+n2))
+        allocate(var_ref_ext(-n2:nx+n2,-n2:ny+n2))
+
+        ! Calculate default 2D Gaussian smoothing kernel
+        filter0 = gauss_values(dx, dx, sigma=sigma, n=n)
+
+        var_old = var 
+
+        var_ref_ext = -9999.0 
+
+        var_ref_ext(1:nx,1:ny) = var 
+        do i = 0, -n2, -1
+            k = -i+1
+            var_ref_ext(i,:) = var_ref_ext(k,:) 
+        end do 
+        do i = nx+1, nx+n2 
+            k = nx + ((nx+1)-i)
+            var_ref_ext(i,:) = var_ref_ext(k,:) 
+        end do 
+
+        do j = 0, -n2, -1
+            k = -j+1
+            var_ref_ext(:,j) = var_ref_ext(:,k) 
+        end do 
+        do j = ny+1, ny+n2 
+            k = ny + ((ny+1)-j)
+            var_ref_ext(:,j) = var_ref_ext(:,k) 
+        end do 
+
+        if (count(var_ref_ext .eq. -9999.0) .gt. 0) then 
+            write(*,*) "Missing points!"
+            stop 
+        end if 
+
+        do j = 1, ny
+        do i = 1, nx
+
+
+            if (mask_apply(i,j)) then
+                ! Apply smoothing to this point 
+
+                ! Limit filter input to neighbors of interest
+                filter = filter0 
+                where(.not. mask_use(i-n2:i+n2,j-n2:j+n2) ) filter = 0.0
+
+                ! If neighbors are available, normalize and perform smoothing  
+                if (sum(filter) .gt. 0.0) then 
+                    filter = filter/sum(filter)
+                    var_ext(i,j) = sum(var_ref_ext(i-n2:i+n2,j-n2:j+n2)*filter) 
+                end if
+
+            else
+                var_ext(i,j) = var_ref_ext(i,j)
+            end if
+
+        end do 
+        end do 
+
+        ! Get variable on normal grid 
+        var = var_ext(1:nx,1:ny)
+
+        return
+    end subroutine smooth_gauss_2D_masked
+
     function gauss_values(dx,dy,sigma,n) result(filt)
         ! Calculate 2D Gaussian smoothing kernel
         ! https://en.wikipedia.org/wiki/Gaussian_blur
@@ -809,7 +936,7 @@ module isos_utils
         return
     end subroutine calc_gaussian_viscosity
 
-    subroutine calc_gaussian_rigidity(He_lith,He_lith_0, He_lith_1,sign,dx,dy)
+    subroutine calc_gaussian_thickness(He_lith,He_lith_0, He_lith_1,sign,dx,dy)
 
         real(wp), intent(IN) :: He_lith_0, He_lith_1,sign, dx, dy
         real(wp), intent(OUT) :: He_lith(:, :)
@@ -857,7 +984,7 @@ module isos_utils
         enddo
         
         return
-    end subroutine calc_gaussian_rigidity
+    end subroutine calc_gaussian_thickness
 
     function midindex(n) result(n2)
         implicit none

--- a/src/isostasy_defs.f90
+++ b/src/isostasy_defs.f90
@@ -23,6 +23,7 @@ module isostasy_defs
 
         character(len=56)       :: mantle      ! [-] Method to prescribe viscosity field
         character(len=56)       :: lithosphere  ! [-] Method to prescribe lithospheric thickness field
+        character(len=56)       :: viscosity_scaling_method
         real(wp)                :: viscosity_scaling
         
         real(wp), allocatable   :: zl(:)    ! [km] Layer boundaries

--- a/src/isostasy_io.f90
+++ b/src/isostasy_io.f90
@@ -112,6 +112,8 @@ module isostasy_io
 
         call nc_write(filename, "z_bed", isos%now%z_bed, units="m", dim1="xc", dim2="yc", &
             dim3="time", ncid=ncid, start=[1,1,n], count=[nx,ny,1])
+        call nc_write(filename,"z_ss", isos%now%z_ss, units="m", &
+            dim1="xc", dim2="yc", dim3="time", ncid=ncid,start=[1,1,n], count=[nx,ny,1])
         call nc_write(filename,"dz_ss", isos%now%dz_ss, units="m", &
             dim1="xc", dim2="yc", dim3="time", ncid=ncid,start=[1,1,n], count=[nx,ny,1])
         call nc_write(filename,"w", isos%now%w, units="m", dim1="xc", dim2="yc", &
@@ -182,6 +184,10 @@ module isostasy_io
         call nc_read(filename, "z_bed", isos%now%z_bed, start=[1,1,1], &
             count=[isos%domain%nx, isos%domain%ny, 1])
         ! write(*,*) "Extrema z_bed: ", minval(isos%now%z_bed), maxval(isos%now%z_bed)
+
+        call nc_read(filename, "z_ss", isos%now%z_ss, start=[1,1,1], &
+            count=[isos%domain%nx, isos%domain%ny, 1])
+        ! write(*,*) "Extrema z_ss: ", minval(isos%now%z_ss), maxval(isos%now%z_ss)
 
         call nc_read(filename, "dz_ss", isos%now%dz_ss, start=[1,1,1], &
             count=[isos%domain%nx, isos%domain%ny, 1])

--- a/src/isostasy_io.f90
+++ b/src/isostasy_io.f90
@@ -136,8 +136,8 @@ module isostasy_io
 
         call nc_write(filename, "log10_eta_eff", log10(isos%domain%eta_eff), units="Pa s", &
             dim1="xc", dim2="yc", dim3="time", ncid=ncid, start=[1,1,n], count=[nx,ny,1])
-        call nc_write(filename, "He_lith", isos%domain%He_lith, units="km", dim1="xc", dim2="yc", &
-            dim3="time", ncid=ncid, start=[1,1,n], count=[nx,ny,1])
+        call nc_write(filename, "He_lith", isos%domain%He_lith, units="km", dim1="xc", &
+            dim2="yc", dim3="time", ncid=ncid, start=[1,1,n], count=[nx,ny,1])
         call nc_write(filename, "mask_active", isos%domain%maskactive, units="1", dim1="xc", dim2="yc", &
             dim3="time", ncid=ncid, start=[1,1,n], count=[nx,ny,1])
         

--- a/src/lv_elva.f90
+++ b/src/lv_elva.f90
@@ -126,6 +126,7 @@ module lv_elva
     
 
     subroutine calc_parallel_layerboundaries(layer_boundaries, He_lith, nl, dl)
+        ! Everything related to layer boundaries is computed in km!
         implicit none
         real(wp), intent(INOUT) :: layer_boundaries(:, :, :)
         real(wp), intent(IN)    :: He_lith(:, :)
@@ -133,7 +134,7 @@ module lv_elva
         real(wp), intent(IN)    :: dl
         integer                 :: k
 
-        layer_boundaries(:, :, 1) = He_lith + 1e3
+        layer_boundaries(:, :, 1) = He_lith
 
         do k = 2, nl
             layer_boundaries(:, :, k) = layer_boundaries(:, :, k-1) + dl
@@ -142,6 +143,7 @@ module lv_elva
     end subroutine calc_parallel_layerboundaries
 
     subroutine calc_equalized_layerboundaries(layer_boundaries, He_lith, nl, zl)
+        ! Everything related to layer boundaries is computed in km!
         implicit none
         real(wp), intent(INOUT) :: layer_boundaries(:, :, :)
         real(wp), intent(IN)    :: He_lith(:, :)
@@ -149,7 +151,7 @@ module lv_elva
         real(wp), intent(IN)    :: zl(:)
         integer                 :: k
 
-        layer_boundaries(:, :, 1) = He_lith + 1e3
+        layer_boundaries(:, :, 1) = He_lith
 
         do k = 2, nl
             layer_boundaries(:, :, k) = zl(k)
@@ -158,6 +160,7 @@ module lv_elva
     end subroutine calc_equalized_layerboundaries
 
     subroutine calc_folded_layerboundaries(layer_boundaries, He_lith, nl, zl)
+        ! Everything related to layer boundaries is computed in km!
         implicit none
         real(wp), intent(INOUT) :: layer_boundaries(:, :, :)
         real(wp), intent(IN)    :: He_lith(:, :)
@@ -165,7 +168,7 @@ module lv_elva
         real(wp), intent(IN)    :: zl(:)
         integer                 :: k
 
-        layer_boundaries(:, :, 1) = He_lith + 1e3
+        layer_boundaries(:, :, 1) = He_lith
         write(*,*) "folded layer boundaries not implemented yet."
         stop
         return
@@ -238,9 +241,11 @@ module lv_elva
             write(*,*) "Value range of effective viscosity: ", minval(eta_eff), maxval(eta_eff)
 
             do k = nl, 2, -1
-                dz = layer_boundaries(:, :, k) - layer_boundaries(:, :, k-1)
 
-                write(*,*) k, minval(dz), maxval(dz), minval(layer_boundaries(:, :, k)), maxval(layer_boundaries(:, :, k)), minval(layer_boundaries(:, :, k-1)), maxval(layer_boundaries(:, :, k-1))
+                ! convert to meters for consistence with W, Wx, Wy
+                dz = (layer_boundaries(:, :, k) - layer_boundaries(:, :, k-1)) * 1e3
+
+                ! write(*,*) k, minval(dz), maxval(dz), minval(layer_boundaries(:, :, k)), maxval(layer_boundaries(:, :, k)), minval(layer_boundaries(:, :, k-1)), maxval(layer_boundaries(:, :, k-1))
 
                 eta_c = eta(:, :, k-1)
                 eta_ratio = eta_c / eta_eff
@@ -261,13 +266,14 @@ module lv_elva
                 end do
 
                 eta_eff = R * eta_eff
-                write(*,*) "Value range of effective viscosity: ", minval(eta_eff), maxval(eta_eff)
 
             end do
         else
             print*,'Number of levels is wrong: nl = ', nl
             stop
         endif
+
+        write(*,*) "Value range of effective viscosity: ", minval(eta_eff), maxval(eta_eff)
 
         return
     end subroutine calc_effective_viscosity


### PR DESCRIPTION
Additional dimensions bug fix - isos_init_ref assumes input fields of dimensions [nxo,nyo] and now uses out2in routine to populate the reference fields. Previously the size of reference Hice and z_bed fields were modified in place to match [nxo,nyo] dimensions, when they should have [nx,ny] dimensions. This is now solved and works.