### PR TITLE
Patch ocean surface initialization

### DIFF
--- a/src/fastisostasy.f90
+++ b/src/fastisostasy.f90
@@ -663,14 +663,6 @@ contains
 
             ! write(*,*) "Updating the BSL contribution..."
             call calc_H_above_bsl(isos%now, isos%par)
-            call calc_sl_contributions(isos)
-
-            if (trim(bsl%method) .eq. "fastiso") then
-                ! minus sign because what goes into ice sheet goes out of ocean.
-                bsl%bsl_now = bsl%bsl_now - isos%now%deltaV_bsl / bsl%A_ocean_now
-            end if
-
-            ! write(*,*) "BSL contribution: ", isos%now%deltaV_bsl
 
             ! write(*,*) "Updating RSL..."
             call calc_rsl(isos%now)
@@ -756,6 +748,13 @@ contains
             end if
         end do
 
+        call calc_sl_contributions(isos)
+        if (trim(bsl%method) .eq. "fastiso") then
+            ! minus sign because what goes into ice sheet goes out of ocean.
+            bsl%bsl_now = bsl%bsl_now - isos%now%deltaV_bsl / bsl%A_ocean_now
+        end if
+        ! write(*,*) "BSL contribution: ", isos%now%deltaV_bsl
+        
         call cropstate2out(isos%out, isos%now, isos%domain)
         ! write(*,*) "extrema of w: ", minval(isos%now%w), maxval(isos%now%w)
         ! write(*,*) "extrema of we: ", minval(isos%now%we), maxval(isos%now%we)

--- a/src/isostasy_io.f90
+++ b/src/isostasy_io.f90
@@ -397,6 +397,10 @@ module isostasy_io
         call nc_write(filename, "z_ss", isos%now%z_ss, units="m", long_name="Sea-surface height", &
               dim1="xc", dim2="yc", dim3="time", start=[1, 1, n], ncid=ncid)
 
+        call nc_write(filename, "dz_ss", isos%now%dz_ss, units="m", &
+            long_name="Sea-surface height change", dim1="xc", dim2="yc", dim3="time", &
+            start=[1, 1, n], ncid=ncid)
+
         call nc_write(filename,"z_bed", isos%now%z_bed, units="m", &
             long_name="Bedrock elevation", dim1="xc", dim2="yc", dim3="time", &
             start=[1, 1, n], ncid=ncid)
@@ -412,10 +416,6 @@ module isostasy_io
         call nc_write(filename, "w_elastic", isos%now%we, units="m", &
             long_name="Displacement (elastic)", &
             dim1="xc", dim2="yc", dim3="time", start=[1, 1, n], ncid=ncid)
-
-        call nc_write(filename, "z_ss_perturbation", isos%now%dz_ss, units="m", &
-            long_name="Geoid displacement", dim1="xc", dim2="yc", dim3="time", &
-            start=[1, 1, n], ncid=ncid)
 
         call nc_write(filename, "column_anomaly", isos%now%canom_full, units="N m^-2", &
             long_name = "Anomaly in column pressure", &

--- a/src/sealevel.f90
+++ b/src/sealevel.f90
@@ -113,7 +113,7 @@ module sealevel
         type(isos_state_class), intent(INOUT)   :: state
         type(isos_param_class), intent(IN)      :: par
 
-        state%H_above_bsl = state%Hice - state%bsl * (par%rho_seawater / par%rho_ice)
+        state%H_above_bsl = state%Hice - (state%bsl - state%z_bed) * (par%rho_seawater / par%rho_ice)
         return
     end subroutine calc_H_above_bsl
 


### PR DESCRIPTION
Initializing ocean surface was sometimes giving 0, which led to NaNs. This is now corrected, as well as the computation of the height of ice above BSL.