### PR TITLE
Reference height above flotation needs to be initialised after barystatic sea level

### DIFF
--- a/src/fastisostasy.f90
+++ b/src/fastisostasy.f90
@@ -612,6 +612,7 @@ contains
         
         isos%now%bsl = bsl%bsl_now
         call calc_z_ss(isos%now%z_ss, isos%now%bsl, isos%now%z_ss, isos%now%dz_ss)
+        call calc_Haf(isos%ref, isos%par)
         call calc_Haf(isos%now, isos%par)
         call calc_masks(isos%now)
 

--- a/src/isostasy_io.f90
+++ b/src/isostasy_io.f90
@@ -288,6 +288,12 @@ module isostasy_io
 
         call nc_write(filename, "maskactive", isos%domain%maskactive, units="1", &
             long_name="Active mask", dim1="xc", dim2="yc", start=[1, 1])
+
+        call nc_write(filename, "H_ice_ref", isos%ref%Hice, units="1", &
+            long_name="Reference ice thickness", dim1="xc", dim2="yc", start=[1, 1])
+
+        call nc_write(filename, "z_bed_ref", isos%ref%z_bed, units="m", &
+            long_name="Reference bedrock elevation", dim1="xc", dim2="yc", start=[1, 1])
         return
 
     end subroutine isos_write_init_extended
@@ -375,7 +381,6 @@ module isostasy_io
         return 
     end subroutine isos_write_step
 
-
     ! Write results to file
     subroutine isos_write_step_extended(isos, filename, time)
 
@@ -445,5 +450,4 @@ module isostasy_io
 
         return 
     end subroutine isos_write_step_extended
-
 end module isostasy_io


### PR DESCRIPTION
The reference Haf was sometimes wrong in the previous version of the code, because it was not initialised properly. This led to a large bedrock subsidence that was unphysical.

Includes:
- the fix of Haf_ref initialisation
- (few) additional output fields that are written to fastisostasy.nc for diagnostics