### PR TITLE
Adaptive dt

### DIFF
--- a/config/Makefile
+++ b/config/Makefile
@@ -91,6 +91,7 @@ isostasy_libs = 	$(objdir)/precision.o \
 					$(objdir)/finite_differences.o \
 					$(objdir)/green_functions.o \
 					$(objdir)/kelvin_function.o \
+					$(objdir)/integrators.o \
 					$(objdir)/sealevel.o \
 					$(objdir)/lv_xlra.o \
 					$(objdir)/barysealevel.o \

--- a/par/test_isostasy_test1a.nml
+++ b/par/test_isostasy_test1a.nml
@@ -61,6 +61,8 @@
     dt_max = 10.0           ! [yr] Maximum dt. Only used if dt_method is "bs32" or "tsit54".
     rtol = 1e-4             ! Relative tol. Only used if dt_method is "bs32" or "tsit54".
     atol = 1e-2             ! Absolute tol. Only used if dt_method is "bs32" or "tsit54".
+    q = 1.0                 ! Exponent for dt adaptation. The higher the most conservative the time stepping.
+                            ! Recommended: q = 1
 /
 
 &barysealevel

--- a/par/test_isostasy_test1b.nml
+++ b/par/test_isostasy_test1b.nml
@@ -61,6 +61,8 @@
     dt_max = 10.0           ! [yr] Maximum dt. Only used if dt_method is "bs32" or "tsit54".
     rtol = 1e-4             ! Relative tol. Only used if dt_method is "bs32" or "tsit54".
     atol = 1e-2             ! Absolute tol. Only used if dt_method is "bs32" or "tsit54".
+    q = 1.0                 ! Exponent for dt adaptation. The higher the most conservative the time stepping.
+                            ! Recommended: q = 1
 /
 
 &barysealevel

--- a/par/test_isostasy_test1c.nml
+++ b/par/test_isostasy_test1c.nml
@@ -61,6 +61,8 @@
     dt_max = 10.0           ! [yr] Maximum dt. Only used if dt_method is "bs32" or "tsit54".
     rtol = 1e-4             ! Relative tol. Only used if dt_method is "bs32" or "tsit54".
     atol = 1e-2             ! Absolute tol. Only used if dt_method is "bs32" or "tsit54".
+    q = 1.0                 ! Exponent for dt adaptation. The higher the most conservative the time stepping.
+                            ! Recommended: q = 1
 /
 
 &barysealevel

--- a/par/test_isostasy_test1d.nml
+++ b/par/test_isostasy_test1d.nml
@@ -61,6 +61,8 @@
     dt_max = 10.0           ! [yr] Maximum dt. Only used if dt_method is "bs32" or "tsit54".
     rtol = 1e-4             ! Relative tol. Only used if dt_method is "bs32" or "tsit54".
     atol = 1e-2             ! Absolute tol. Only used if dt_method is "bs32" or "tsit54".
+    q = 1.0                 ! Exponent for dt adaptation. The higher the most conservative the time stepping.
+                            ! Recommended: q = 1
 /
 
 &barysealevel

--- a/par/test_isostasy_test1e.nml
+++ b/par/test_isostasy_test1e.nml
@@ -61,6 +61,8 @@
     dt_max = 10.0           ! [yr] Maximum dt. Only used if dt_method is "bs32" or "tsit54".
     rtol = 1e-4             ! Relative tol. Only used if dt_method is "bs32" or "tsit54".
     atol = 1e-2             ! Absolute tol. Only used if dt_method is "bs32" or "tsit54".
+    q = 1.0                 ! Exponent for dt adaptation. The higher the most conservative the time stepping.
+                            ! Recommended: q = 1
 /
 
 &barysealevel

--- a/par/test_isostasy_test2a.nml
+++ b/par/test_isostasy_test2a.nml
@@ -61,6 +61,8 @@
     dt_max = 10.0           ! [yr] Maximum dt. Only used if dt_method is "bs32" or "tsit54".
     rtol = 1e-4             ! Relative tol. Only used if dt_method is "bs32" or "tsit54".
     atol = 1e-2             ! Absolute tol. Only used if dt_method is "bs32" or "tsit54".
+    q = 1.0                 ! Exponent for dt adaptation. The higher the most conservative the time stepping.
+                            ! Recommended: q = 1
 /
 
 &barysealevel

--- a/par/test_isostasy_test2b.nml
+++ b/par/test_isostasy_test2b.nml
@@ -61,6 +61,8 @@
     dt_max = 10.0           ! [yr] Maximum dt. Only used if dt_method is "bs32" or "tsit54".
     rtol = 1e-4             ! Relative tol. Only used if dt_method is "bs32" or "tsit54".
     atol = 1e-2             ! Absolute tol. Only used if dt_method is "bs32" or "tsit54".
+    q = 1.0                 ! Exponent for dt adaptation. The higher the most conservative the time stepping.
+                            ! Recommended: q = 1
 /
 
 &barysealevel

--- a/par/test_isostasy_test2c.nml
+++ b/par/test_isostasy_test2c.nml
@@ -61,6 +61,8 @@
     dt_max = 10.0           ! [yr] Maximum dt. Only used if dt_method is "bs32" or "tsit54".
     rtol = 1e-4             ! Relative tol. Only used if dt_method is "bs32" or "tsit54".
     atol = 1e-2             ! Absolute tol. Only used if dt_method is "bs32" or "tsit54".
+    q = 1.0                 ! Exponent for dt adaptation. The higher the most conservative the time stepping.
+                            ! Recommended: q = 1
 /
 
 &barysealevel

--- a/par/test_isostasy_test3a.nml
+++ b/par/test_isostasy_test3a.nml
@@ -59,6 +59,8 @@
     dt_max = 10.0           ! [yr] Maximum dt. Only used if dt_method is "bs32" or "tsit54".
     rtol = 1e-4             ! Relative tol. Only used if dt_method is "bs32" or "tsit54".
     atol = 1e-2             ! Absolute tol. Only used if dt_method is "bs32" or "tsit54".
+    q = 1.0                 ! Exponent for dt adaptation. The higher the most conservative the time stepping.
+                            ! Recommended: q = 1
 /
 
 &barysealevel

--- a/par/test_isostasy_test3b.nml
+++ b/par/test_isostasy_test3b.nml
@@ -60,6 +60,8 @@
     dt_max = 10.0           ! [yr] Maximum dt. Only used if dt_method is "bs32" or "tsit54".
     rtol = 1e-4             ! Relative tol. Only used if dt_method is "bs32" or "tsit54".
     atol = 1e-2             ! Absolute tol. Only used if dt_method is "bs32" or "tsit54".
+    q = 1.0                 ! Exponent for dt adaptation. The higher the most conservative the time stepping.
+                            ! Recommended: q = 1
 /
 
 &barysealevel

--- a/par/test_isostasy_test3c.nml
+++ b/par/test_isostasy_test3c.nml
@@ -59,6 +59,8 @@
     dt_max = 10.0           ! [yr] Maximum dt. Only used if dt_method is "bs32" or "tsit54".
     rtol = 1e-4             ! Relative tol. Only used if dt_method is "bs32" or "tsit54".
     atol = 1e-2             ! Absolute tol. Only used if dt_method is "bs32" or "tsit54".
+    q = 1.0                 ! Exponent for dt adaptation. The higher the most conservative the time stepping.
+                            ! Recommended: q = 1
 /
 
 &barysealevel

--- a/par/test_isostasy_test3d.nml
+++ b/par/test_isostasy_test3d.nml
@@ -59,6 +59,8 @@
     dt_max = 10.0           ! [yr] Maximum dt. Only used if dt_method is "bs32" or "tsit54".
     rtol = 1e-4             ! Relative tol. Only used if dt_method is "bs32" or "tsit54".
     atol = 1e-2             ! Absolute tol. Only used if dt_method is "bs32" or "tsit54".
+    q = 1.0                 ! Exponent for dt adaptation. The higher the most conservative the time stepping.
+                            ! Recommended: q = 1
 /
 
 &barysealevel

--- a/par/test_isostasy_test4a.nml
+++ b/par/test_isostasy_test4a.nml
@@ -63,6 +63,8 @@
     dt_max = 10.0           ! [yr] Maximum dt. Only used if dt_method is "bs32" or "tsit54".
     rtol = 1e-4             ! Relative tol. Only used if dt_method is "bs32" or "tsit54".
     atol = 1e-2             ! Absolute tol. Only used if dt_method is "bs32" or "tsit54".
+    q = 1.0                 ! Exponent for dt adaptation. The higher the most conservative the time stepping.
+                            ! Recommended: q = 1
 /
 
 &barysealevel

--- a/par/test_isostasy_test4b.nml
+++ b/par/test_isostasy_test4b.nml
@@ -63,6 +63,8 @@
     dt_max = 10.0           ! [yr] Maximum dt. Only used if dt_method is "bs32" or "tsit54".
     rtol = 1e-4             ! Relative tol. Only used if dt_method is "bs32" or "tsit54".
     atol = 1e-2             ! Absolute tol. Only used if dt_method is "bs32" or "tsit54".
+    q = 1.0                 ! Exponent for dt adaptation. The higher the most conservative the time stepping.
+                            ! Recommended: q = 1
 /
 
 &barysealevel

--- a/par/test_isostasy_test5a.nml
+++ b/par/test_isostasy_test5a.nml
@@ -61,6 +61,8 @@
     dt_max = 10.0           ! [yr] Maximum dt. Only used if dt_method is "bs32" or "tsit54".
     rtol = 1e-4             ! Relative tol. Only used if dt_method is "bs32" or "tsit54".
     atol = 1e-2             ! Absolute tol. Only used if dt_method is "bs32" or "tsit54".
+    q = 1.0                 ! Exponent for dt adaptation. The higher the most conservative the time stepping.
+                            ! Recommended: q = 1
 /
 
 &barysealevel

--- a/par/test_isostasy_test5b.nml
+++ b/par/test_isostasy_test5b.nml
@@ -60,6 +60,8 @@
     dt_max = 10.0           ! [yr] Maximum dt. Only used if dt_method is "bs32" or "tsit54".
     rtol = 1e-4             ! Relative tol. Only used if dt_method is "bs32" or "tsit54".
     atol = 1e-2             ! Absolute tol. Only used if dt_method is "bs32" or "tsit54".
+    q = 1.0                 ! Exponent for dt adaptation. The higher the most conservative the time stepping.
+                            ! Recommended: q = 1
 /
 
 &barysealevel

--- a/src/fastisostasy.f90
+++ b/src/fastisostasy.f90
@@ -1009,6 +1009,7 @@ contains
         call nml_read(filename,group,"dt_min", par%dt_min)
         call nml_read(filename,group,"dt_max", par%dt_max)
         call nml_read(filename,group,"dt_init", par%dt_init)
+        call nml_read(filename,group,"q", par%q)
 
         return
     end subroutine isos_par_load

--- a/src/integrators.f90
+++ b/src/integrators.f90
@@ -15,16 +15,17 @@ contains
         type(ode_class), intent(inout) :: ode
         type(isos_class), intent(inout) :: isos
 
-        interface
-            function ode_rhs(x, t, isos) result(dxdt)
+        abstract interface
+            function ode_rhs_(x, t, isos) result(dxdt)
                 use isostasy_defs, only : wp, isos_class
                 implicit none
                 real(wp), intent(in) :: t
                 real(wp), intent(in) :: x(:, :)
                 type(isos_class), intent(inout) :: isos
                 real(wp), dimension(size(x, 1), size(x, 2)) :: dxdt
-            end function ode_rhs
+            end function ode_rhs_
         end interface
+        procedure(ode_rhs_) :: ode_rhs
 
         do while (ode%t < tf)
             ! handle last partial step cleanly
@@ -45,16 +46,17 @@ contains
         type(isos_class), intent(inout) :: isos
         real(wp) :: t, h
 
-        interface
-            function ode_rhs(x, t, isos) result(dxdt)
+        abstract interface
+            function ode_rhs_(x, t, isos) result(dxdt)
                 use isostasy_defs, only : wp, isos_class
                 implicit none
                 real(wp), intent(in) :: t
                 real(wp), intent(in) :: x(:, :)
                 type(isos_class), intent(inout) :: isos
                 real(wp), dimension(size(x, 1), size(x, 2)) :: dxdt
-            end function ode_rhs
+            end function ode_rhs_
         end interface
+        procedure(ode_rhs_) :: ode_rhs
 
         do while (ode%t < tf)
             ! handle last partial step cleanly
@@ -81,16 +83,17 @@ contains
         type(isos_class), intent(inout) :: isos
         real(wp) :: error, tol
 
-        interface
-            function ode_rhs(x, t, isos) result(dxdt)
+        abstract interface
+            function ode_rhs_(x, t, isos) result(dxdt)
                 use isostasy_defs, only : wp, isos_class
                 implicit none
                 real(wp), intent(in) :: t
                 real(wp), intent(in) :: x(:, :)
                 type(isos_class), intent(inout) :: isos
                 real(wp), dimension(size(x, 1), size(x, 2)) :: dxdt
-            end function ode_rhs
+            end function ode_rhs_
         end interface
+        procedure(ode_rhs_) :: ode_rhs
 
         do while (ode%t < tf)
             ! handle last partial step cleanly
@@ -116,7 +119,7 @@ contains
                 ode%x = ode%x2
                 isos%now%w = ode%x
                 ode%t = ode%t + ode%dt
-                ode%dt = min(ode%dt * 1/error, isos%par%dt_max)
+                ode%dt = min(ode%dt * (1/error) ** (1/isos%par%q), isos%par%dt_max)
                 write(*,*) "FastIso: t =", ode%t, " dt =", ode%dt, " error =", error
             else
                 ! Reject step and reduce time step
@@ -131,16 +134,17 @@ contains
         type(ode_class), intent(inout) :: ode
         type(isos_class), intent(inout) :: isos
 
-        interface
-            function ode_rhs(x, t, isos) result(dxdt)
+        abstract interface
+            function ode_rhs_(x, t, isos) result(dxdt)
                 use isostasy_defs, only : wp, isos_class
                 implicit none
                 real(wp), intent(in) :: t
                 real(wp), intent(in) :: x(:, :)
                 type(isos_class), intent(inout) :: isos
                 real(wp), dimension(size(x, 1), size(x, 2)) :: dxdt
-            end function ode_rhs
+            end function ode_rhs_
         end interface
+        procedure(ode_rhs_) :: ode_rhs
 
         real(wp) :: error, tol
         ! Coefficients for the Tsitouras 5(4) method
@@ -187,7 +191,7 @@ contains
                 ode%x = ode%x2
                 isos%now%w = ode%x
                 ode%t = ode%t + ode%dt
-                ode%dt = min(ode%dt * 1/error, isos%par%dt_max)
+                ode%dt = min(ode%dt * (1/error) ** (1/isos%par%q), isos%par%dt_max)
                 write(*,*) "FastIso: t =", ode%t, " dt =", ode%dt, " error =", error
             else
                 ! Reject step and reduce time step

--- a/src/isostasy_defs.f90
+++ b/src/isostasy_defs.f90
@@ -95,6 +95,7 @@ module isostasy_defs
         real(wp) :: dt_min
         real(wp) :: dt_max
         real(wp) :: dt_init
+        real(wp) :: q
         
     end type
 


### PR DESCRIPTION
This pull request solves some a segmentation fault that was happening in the integrator interface on some compilers. It also introduces a new parameter, `q`, to control the exponent for adaptive time step adjustment in the isostasy test cases and integrator routines. The change is applied consistently across parameter files, Fortran modules, and adaptive stepper logic, enhancing the flexibility and conservativeness of time-stepping schemes.

**Fixed integrator interface**

* Refactored all integrator subroutines to use an abstract interface for the ODE right-hand-side function, improving code clarity and maintainability. [[1]](diffhunk://#diff-0ab301d9654ff88bb1fe575604b93c9b10fe682043a9ac2d2027526a5739837cL18-R28) [[2]](diffhunk://#diff-0ab301d9654ff88bb1fe575604b93c9b10fe682043a9ac2d2027526a5739837cL48-R59) [[3]](diffhunk://#diff-0ab301d9654ff88bb1fe575604b93c9b10fe682043a9ac2d2027526a5739837cL84-R96) [[4]](diffhunk://#diff-0ab301d9654ff88bb1fe575604b93c9b10fe682043a9ac2d2027526a5739837cL134-R147)

These changes collectively provide more control and transparency over the adaptive time stepping behavior in isostasy simulations, and improve the maintainability of the codebase.

**Parameterization of adaptive time stepping:**

* Added the `q` parameter to all isostasy test case namelists (e.g., `par/test_isostasy_test1a.nml`, ..., `par/test_isostasy_test5b.nml`) to allow user control of the exponent for time step adaptation, with documentation recommending `q = 1`. [[1]](diffhunk://#diff-d1cb6867142a798c7b17ab32621b1f9cd007443f19072fbfb37e3bd2bb2bf11fR64-R65) [[2]](diffhunk://#diff-211551444a9e603399cd7188b7f33d7ee93c1d282582f0d59b4096591b453c22R64-R65) [[3]](diffhunk://#diff-6f7ee1b63756f4a20bf0b0ab31b44ba1658a074e3278d93fb116471522a5df75R64-R65) [[4]](diffhunk://#diff-8766989fffb1172f04a45afda167d158bfea56d0c88a4ce9468740596115ae9bR64-R65) [[5]](diffhunk://#diff-076e1e3afc4bb1cc67afeb2a1613fba55083829a244a2449ae5c304c57dbdaffR64-R65) [[6]](diffhunk://#diff-712926c949b20f2fc502e74c6009f7b117d9afd93ecacdbff09a7f35aeeb3fa6R64-R65) [[7]](diffhunk://#diff-bfb04fd3012f05922bb659b04bc6e155d661a22c56186a18519ff843a9fb0745R64-R65) [[8]](diffhunk://#diff-dbf69da4d64e46aa0e4744e0f626b9c24b0b4f8c7cc92c35d1217db255f4713dR64-R65) [[9]](diffhunk://#diff-7e06b31a5b3c095018482e211a0ed2a9ace1b8fced326b0a8ec7fb26dc4f2493R62-R63) [[10]](diffhunk://#diff-a5f30b61ab9a582aa2bbf051c7176dde9bf31626de2ce0efbdb2937107c45a23R63-R64) [[11]](diffhunk://#diff-e2e8bfd41f132929603663b1c4ed86218dba6a943ca9559aef4c31f539737f03R62-R63) [[12]](diffhunk://#diff-258dfac976a2797e05b87882b7c00ec22104d118da1a562a7b91830b450c4335R62-R63) [[13]](diffhunk://#diff-007a70a8fce31636d01b71ef01be7c8cc5baf7bca975a7ac8b22e6946247e281R66-R67) [[14]](diffhunk://#diff-da46e4c0b84d198d5342779edbf1023b4cbbda6f004d513e0d460bb02ffaa21bR66-R67) [[15]](diffhunk://#diff-954df0315184174f36008da0105046dc78e3ef4cae5f0b5e1117ac85b95dbf17R64-R65) [[16]](diffhunk://#diff-963cd1bc58fef6bd2dedbc53d2c337927661b7b6cba5f7625c2a3598b1f6a126R63-R64)

* Updated the `isostasy_defs` module and parameter loading routines to include the new `q` member in the `isostasy_par` type and to read it from the namelist files. [[1]](diffhunk://#diff-8e466943443025b8020d87f8a2b18508f89977be0a14d6e3218a2488192c6545R98) [[2]](diffhunk://#diff-bca296be9b858ad8c5b05f8632adec26c74576856b711cea744a71b44f1a3f0eR1012)

**Integration logic updates:**

* Modified adaptive integrators (`step_bs32` and `step_tsit54` in `src/integrators.f90`) to use the new `q` parameter in the time step adaptation formula, replacing the fixed exponent with a configurable one: `ode%dt = min(ode%dt * (1/error) ** (1/isos%par%q), isos%par%dt_max)`. [[1]](diffhunk://#diff-0ab301d9654ff88bb1fe575604b93c9b10fe682043a9ac2d2027526a5739837cL119-R122) [[2]](diffhunk://#diff-0ab301d9654ff88bb1fe575604b93c9b10fe682043a9ac2d2027526a5739837cL190-R194)